### PR TITLE
Use DIM_Y for case DIM_Y in Histogram2 getGrid (#508)

### DIFF
--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
@@ -175,7 +175,7 @@ public class Histogram2 extends AbstractHistogram implements Histogram2D {
         case DIM_X:
             return xProjection.get(DIM_X, index);
         case DIM_Y:
-            return yProjection.get(DIM_X, index);
+            return yProjection.get(DIM_Y, index);
         default:
             throw new IndexOutOfBoundsException("dim Index out of bound 2");
         }


### PR DESCRIPTION
Histogram2's implementation of getGrid was using DIM_X for they y projection as well as the x projection. This changes it to properly use DIM_Y.