### PR TITLE
mavencentral: update repo hostname

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
@@ -416,7 +416,7 @@
             <distributionManagement>
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>


### PR DESCRIPTION
Follow-up to #534
As of feb '21, new mavencentral projects are located on s01.oss.sonatype.org instead of oss.sonatype.org.
With this PR it should be possible to deploy to mavencentral again.