### PR TITLE
resolve performance issue caused by using DoubleArrayCache.getArrayExact

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/transforms/DefaultAxisTransform.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/transforms/DefaultAxisTransform.java
@@ -25,12 +25,12 @@ public class DefaultAxisTransform extends AbstractAxisTransform {
 
     @Override
     public double getRoundedMaximumRange(final double max) {
-        return Math.floor(max);
+        return Math.ceil(max);
     }
 
     @Override
     public double getRoundedMinimumRange(final double min) {
-        return Math.ceil(min);
+        return Math.floor(min);
     }
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/datareduction/DefaultDataReducer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/datareduction/DefaultDataReducer.java
@@ -56,12 +56,12 @@ public class DefaultDataReducer implements RendererDataReducer {
     public int reducePoints(final double[] xValues, final double[] yValues, final double[] xPointErrorsPos,
             final double[] xPointErrorsNeg, final double[] yPointErrorsPos, final double[] yPointErrorsNeg,
             final String[] styles, final boolean[] pointSelected, final int indexMin, final int indexMax) {
-        AssertUtils.nonEmptyArray("xValues", xValues);
-        final int defaultDataLength = xValues.length;
-        AssertUtils.checkArrayDimension("yValues", yValues, defaultDataLength);
-        AssertUtils.checkArrayDimension("pointSelected", pointSelected, defaultDataLength);
-        AssertUtils.gtEqThanZero("indexMax", indexMin);
+        AssertUtils.gtEqThanZero("indexMin", indexMin);
         AssertUtils.gtThanZero("indexMax", indexMax);
+        AssertUtils.indexOrder(indexMin,"indexMin", indexMax,"indexMax");
+        AssertUtils.checkArrayCapacity("xValues", xValues, indexMax);
+        AssertUtils.checkArrayCapacity("yValues", yValues, indexMax);
+        AssertUtils.checkArrayCapacity("pointSelected", pointSelected, indexMax);
 
         final boolean xErrorPos = xPointErrorsPos != null;
         final boolean xErrorNeg = xPointErrorsNeg != null;
@@ -69,15 +69,15 @@ public class DefaultDataReducer implements RendererDataReducer {
         final boolean yErrorNeg = yPointErrorsNeg != null;
 
         if (xErrorPos && xErrorNeg && yErrorPos && yErrorNeg) {
-            AssertUtils.checkArrayDimension("xPointErrorsPos", xPointErrorsPos, defaultDataLength);
-            AssertUtils.checkArrayDimension("xPointErrorsNeg", xPointErrorsNeg, defaultDataLength);
-            AssertUtils.checkArrayDimension("yPointErrorsPos", yPointErrorsPos, defaultDataLength);
-            AssertUtils.checkArrayDimension("yPointErrorsNeg", yPointErrorsNeg, defaultDataLength);
+            AssertUtils.checkArrayCapacity("xPointErrorsPos", xPointErrorsPos, indexMax);
+            AssertUtils.checkArrayCapacity("xPointErrorsNeg", xPointErrorsNeg, indexMax);
+            AssertUtils.checkArrayCapacity("yPointErrorsPos", yPointErrorsPos, indexMax);
+            AssertUtils.checkArrayCapacity("yPointErrorsNeg", yPointErrorsNeg, indexMax);
             return reducePointsInternal(xValues, yValues, xPointErrorsPos, xPointErrorsNeg, yPointErrorsPos,
                     yPointErrorsNeg, styles, pointSelected, indexMin, indexMax);
         } else if (yErrorPos && yErrorNeg) {
-            AssertUtils.checkArrayDimension("yPointErrorsPos", yPointErrorsPos, defaultDataLength);
-            AssertUtils.checkArrayDimension("yPointErrorsNeg", yPointErrorsNeg, defaultDataLength);
+            AssertUtils.checkArrayCapacity("yPointErrorsPos", yPointErrorsPos, indexMax);
+            AssertUtils.checkArrayCapacity("yPointErrorsNeg", yPointErrorsNeg, indexMax);
             return reducePointsInternal(xValues, yValues, yPointErrorsPos, yPointErrorsNeg, styles, pointSelected,
                     indexMin, indexMax);
         } else {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/CachedDataPoints.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/CachedDataPoints.java
@@ -69,16 +69,16 @@ class CachedDataPoints {
 
     public CachedDataPoints(final int indexMin, final int indexMax, final int dataLength, final boolean full) {
         maxDataCount = dataLength;
-        xValues = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
-        yValues = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+        xValues = DoubleArrayCache.getInstance().getArray(maxDataCount);
+        yValues = DoubleArrayCache.getInstance().getArray(maxDataCount);
         styles = ArrayCache.getCachedStringArray(STYLES2, dataLength);
         this.indexMin = indexMin;
         this.indexMax = indexMax;
-        errorYNeg = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
-        errorYPos = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+        errorYNeg = DoubleArrayCache.getInstance().getArray(maxDataCount);
+        errorYPos = DoubleArrayCache.getInstance().getArray(maxDataCount);
         if (full) {
-            errorXNeg = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
-            errorXPos = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+            errorXNeg = DoubleArrayCache.getInstance().getArray(maxDataCount);
+            errorXPos = DoubleArrayCache.getInstance().getArray(maxDataCount);
         }
         selected = ArrayCache.getCachedBooleanArray(SELECTED2, dataLength);
         ArrayUtils.fillArray(styles, null);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/ErrorDataSetRenderer.java
@@ -479,8 +479,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
 
         final int nDataCount = localCachedPoints.actualDataCount;
         final int nPolygoneEdges = 2 * nDataCount;
-        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
-        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
+        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArray(nPolygoneEdges);
+        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArray(nPolygoneEdges);
 
         final int xend = nPolygoneEdges - 1;
         for (int i = 0; i < nDataCount; i++) {
@@ -520,8 +520,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
 
         final int nDataCount = localCachedPoints.actualDataCount;
         final int nPolygoneEdges = 2 * nDataCount;
-        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
-        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
+        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArray(nPolygoneEdges);
+        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArray(nPolygoneEdges);
 
         final int xend = nPolygoneEdges - 1;
         int count = 0;
@@ -733,8 +733,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(n + 2);
-        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(n + 2);
+        final double[] newX = DoubleArrayCache.getInstance().getArray(n + 2);
+        final double[] newY = DoubleArrayCache.getInstance().getArray(n + 2);
 
         final double zero = localCachedPoints.yZero;
         System.arraycopy(localCachedPoints.xValues, 0, newX, 0, n);
@@ -765,8 +765,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
-        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
+        final double[] newX = DoubleArrayCache.getInstance().getArray(2 * (n + 1));
+        final double[] newY = DoubleArrayCache.getInstance().getArray(2 * (n + 1));
 
         final double xRange = localCachedPoints.xMax - localCachedPoints.xMin;
         double diffLeft;
@@ -818,10 +818,10 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] xCp1 = DoubleArrayCache.getInstance().getArrayExact(n);
-        final double[] yCp1 = DoubleArrayCache.getInstance().getArrayExact(n);
-        final double[] xCp2 = DoubleArrayCache.getInstance().getArrayExact(n);
-        final double[] yCp2 = DoubleArrayCache.getInstance().getArrayExact(n);
+        final double[] xCp1 = DoubleArrayCache.getInstance().getArray(n);
+        final double[] yCp1 = DoubleArrayCache.getInstance().getArray(n);
+        final double[] xCp2 = DoubleArrayCache.getInstance().getArray(n);
+        final double[] yCp2 = DoubleArrayCache.getInstance().getArray(n);
 
         BezierCurve.calcCurveControlPoints(localCachedPoints.xValues, localCachedPoints.yValues, xCp1, yCp1, xCp2, yCp2,
                 localCachedPoints.actualDataCount);
@@ -869,8 +869,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
-        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
+        final double[] newX = DoubleArrayCache.getInstance().getArray(2 * (n + 1));
+        final double[] newY = DoubleArrayCache.getInstance().getArray(2 * (n + 1));
 
         final double xRange = localCachedPoints.xMax - localCachedPoints.xMin;
         double diffLeft;
@@ -963,8 +963,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * n);
-        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * n);
+        final double[] newX = DoubleArrayCache.getInstance().getArray(2 * n);
+        final double[] newY = DoubleArrayCache.getInstance().getArray(2 * n);
 
         for (int i = 0; i < n - 1; i++) {
             newX[2 * i] = localCachedPoints.xValues[i];

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/utils/AssertUtils.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/utils/AssertUtils.java
@@ -90,6 +90,46 @@ public final class AssertUtils {
         }
     }
 
+    public static void checkArrayCapacity(final String name, final boolean[] array, final int requiredLength) {
+        AssertUtils.notNull(name, array);
+        AssertUtils.nonEmptyArray(name, array);
+        if (array.length < requiredLength) {
+            throw new IllegalArgumentException("The " + name + " boolean array must have a length of at least " + requiredLength);
+        }
+    }
+
+    public static void checkArrayCapacity(final String name, final byte[] array, final int requiredLength) {
+        AssertUtils.notNull(name, array);
+        AssertUtils.nonEmptyArray(name, array);
+        if (array.length < requiredLength) {
+            throw new IllegalArgumentException("The " + name + " byte array must have a length of at least " + requiredLength);
+        }
+    }
+
+    public static void checkArrayCapacity(final String name, final double[] array, final int requiredLength) {
+        AssertUtils.notNull(name, array);
+        AssertUtils.nonEmptyArray(name, array);
+        if (array.length < requiredLength) {
+            throw new IllegalArgumentException("The " + name + " double array must have a length of at least " + requiredLength);
+        }
+    }
+
+    public static void checkArrayCapacity(final String name, final float[] array, final int requiredLength) {
+        AssertUtils.notNull(name, array);
+        AssertUtils.nonEmptyArray(name, array);
+        if (array.length < requiredLength) {
+            throw new IllegalArgumentException("The " + name + " float array must have a length of at least " + requiredLength);
+        }
+    }
+
+    public static void checkArrayCapacity(final String name, final int[] array, final int requiredLength) {
+        AssertUtils.notNull(name, array);
+        AssertUtils.nonEmptyArray(name, array);
+        if (array.length < requiredLength) {
+            throw new IllegalArgumentException("The " + name + " int array must have a length of at least " + requiredLength);
+        }
+    }
+
     /**
      * Asserts that the specified arrays have the same length.
      *


### PR DESCRIPTION
displaying live data from data sets with fluctuating size created a lot of GC pressure because the DoubleArrayCache required a new allocation almost every call to getArrayExact

adjusting the ErrorDataSetRenderer and related classes to call DoubleArrayCache.getArray (using best fit strategy) instead removes this overhead

the time spend in the cache easily took 90% of the render time in our case, because the cache list grews quite large