### PR TITLE
remove fastutil dependency

### DIFF
--- a/chartfx-dataset/pom.xml
+++ b/chartfx-dataset/pom.xml
@@ -20,11 +20,6 @@
 	</description>
 
     <dependencies>
-        <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
-            <version>8.3.1</version>
-        </dependency>
         <!-- micro-benchmarking framework -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/DoubleDataSet.java
@@ -9,7 +9,7 @@ import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.DataSet2D;
 import io.fair_acc.dataset.EditableDataSet;
 
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 
 /**
  * Implementation of the {@code DataSet} interface which stores x,y values in two separate arrays. It provides methods

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/DoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/DoubleErrorDataSet.java
@@ -10,7 +10,7 @@ import io.fair_acc.dataset.DataSet2D;
 import io.fair_acc.dataset.DataSetError;
 import io.fair_acc.dataset.EditableDataSet;
 
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 
 /**
  * Implementation of the {@code DataSetError} interface which stores x,y, +eyn, and -eyn values in separate double

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/FloatDataSet.java
@@ -10,7 +10,7 @@ import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.DataSet2D;
 import io.fair_acc.dataset.EditableDataSet;
 
-import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import io.fair_acc.dataset.spi.fastutil.FloatArrayList;
 
 /**
  * Implementation of the <code>DataSet</code> interface which stores x,y values in two separate arrays. It provides

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/MultiDimDoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/MultiDimDoubleDataSet.java
@@ -8,7 +8,7 @@ import io.fair_acc.dataset.utils.AssertUtils;
 import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.EditableDataSet;
 
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 
 /**
  * Implementation of the {@code DataSet} interface which stores x,y,... values in nDim separate arrays. It provides

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/ArrayUtil.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/ArrayUtil.java
@@ -1,0 +1,27 @@
+package io.fair_acc.dataset.spi.fastutil;
+
+/**
+ * @author Florian Enner
+ * @since 26 Mär 2023
+ */
+class ArrayUtil {
+
+    /** Ensures that a range given by its first (inclusive) and last (exclusive) elements fits an array of given length.
+     *
+     * <p>This method may be used whenever an array range check is needed.
+     *
+     * @param arrayLength an array length.
+     * @param from a start index (inclusive).
+     * @param to an end index (inclusive).
+     * @throws IllegalArgumentException if {@code from} is greater than {@code to}.
+     * @throws ArrayIndexOutOfBoundsException if {@code from} or {@code to} are greater than {@code arrayLength} or negative.
+     */
+    public static void ensureFromTo(final int arrayLength, final int from, final int to) {
+        if (from < 0) throw new ArrayIndexOutOfBoundsException("Start index (" + from + ") is negative");
+        if (from > to) throw new IllegalArgumentException("Start index (" + from + ") is greater than end index (" + to + ")");
+        if (to > arrayLength) throw new ArrayIndexOutOfBoundsException("End index (" + to + ") is greater than array length (" + arrayLength + ")");
+    }
+
+    public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+}

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/ArrayUtil.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/ArrayUtil.java
@@ -1,8 +1,7 @@
 package io.fair_acc.dataset.spi.fastutil;
 
 /**
- * @author Florian Enner
- * @since 26 Mär 2023
+ * Utilities for shading fastutil lists.
  */
 class ArrayUtil {
 

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright (C) 2002-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fair_acc.dataset.spi.fastutil;
+import it.unimi.dsi.fastutil.doubles.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.RandomAccess;
+import java.util.NoSuchElementException;
+/**
+ * A type-specific array-based list; provides some additional methods that use
+ * polymorphism to avoid (un)boxing.
+ *
+ * <p>
+ * This class implements a lightweight, fast, open, optimized, reuse-oriented
+ * version of array-based lists. Instances of this class represent a list with
+ * an array that is enlarged as needed when new entries are created (by doubling
+ * its current length), but is <em>never</em> made smaller (even on a
+ * {@link #clear()}). A family of {@linkplain #trim() trimming methods} lets you
+ * control the size of the backing array; this is particularly useful if you
+ * reuse instances of this class. Range checks are equivalent to those of
+ * {@link java.util}'s classes, but they are delayed as much as possible. The
+ * backing array is exposed by the {@link #elements()} method.
+ *
+ * <p>
+ * This class implements the bulk methods {@code removeElements()},
+ * {@code addElements()} and {@code getElements()} using high-performance system
+ * calls (e.g., {@link System#arraycopy(Object,int,Object,int,int)
+ * System.arraycopy()} instead of expensive loops.
+ *
+ * @see java.util.ArrayList
+ */
+public class DoubleArrayList extends AbstractDoubleList implements RandomAccess, Cloneable, java.io.Serializable {
+    private static final long serialVersionUID = -7046029254386353130L;
+    /** The initial default capacity of an array list. */
+    public static final int DEFAULT_INITIAL_CAPACITY = 10;
+    /** The backing array. */
+    protected transient double a[];
+    /**
+     * The current actual size of the list (never greater than the backing-array
+     * length).
+     */
+    protected int size;
+    /**
+     * Creates a new array list using a given array.
+     *
+     * <p>
+     * This constructor is only meant to be used by the wrapping methods.
+     *
+     * @param a
+     *            the array that will be used to back this array list.
+     */
+    protected DoubleArrayList(final double a[], @SuppressWarnings("unused") boolean dummy) {
+        this.a = a;
+    }
+    /**
+     * Creates a new array list with given capacity.
+     *
+     * @param capacity
+     *            the initial capacity of the array list (may be 0).
+     */
+
+    public DoubleArrayList(final int capacity) {
+        if (capacity < 0)
+            throw new IllegalArgumentException("Initial capacity (" + capacity + ") is negative");
+        if (capacity == 0)
+            a = DoubleArrays.EMPTY_ARRAY;
+        else
+            a = new double[capacity];
+    }
+    /** Creates a new array list with {@link #DEFAULT_INITIAL_CAPACITY} capacity. */
+
+    public DoubleArrayList() {
+        a = DoubleArrays.DEFAULT_EMPTY_ARRAY; // We delay allocation
+    }
+    /**
+     * Creates a new array list and fills it with a given collection.
+     *
+     * @param c
+     *            a collection that will be used to fill the array list.
+     */
+    public DoubleArrayList(final Collection<? extends Double> c) {
+        this(c.size());
+        size = DoubleIterators.unwrap(DoubleIterators.asDoubleIterator(c.iterator()), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific collection.
+     *
+     * @param c
+     *            a type-specific collection that will be used to fill the array
+     *            list.
+     */
+    public DoubleArrayList(final DoubleCollection c) {
+        this(c.size());
+        size = DoubleIterators.unwrap(c.iterator(), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific list.
+     *
+     * @param l
+     *            a type-specific list that will be used to fill the array list.
+     */
+    public DoubleArrayList(final DoubleList l) {
+        this(l.size());
+        l.getElements(0, a, 0, size = l.size());
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     */
+    public DoubleArrayList(final double a[]) {
+        this(a, 0, a.length);
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     * @param offset
+     *            the first element to use.
+     * @param length
+     *            the number of elements to use.
+     */
+    public DoubleArrayList(final double a[], final int offset, final int length) {
+        this(length);
+        System.arraycopy(a, offset, this.a, 0, length);
+        size = length;
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by an
+     * iterator..
+     *
+     * @param i
+     *            an iterator whose returned elements will fill the array list.
+     */
+    public DoubleArrayList(final Iterator<? extends Double> i) {
+        this();
+        while (i.hasNext())
+            this.add((i.next()).doubleValue());
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by a
+     * type-specific iterator..
+     *
+     * @param i
+     *            a type-specific iterator whose returned elements will fill the
+     *            array list.
+     */
+    public DoubleArrayList(final DoubleIterator i) {
+        this();
+        while (i.hasNext())
+            this.add(i.nextDouble());
+    }
+    /**
+     * Returns the backing array of this list.
+     *
+     * @return the backing array.
+     */
+    public double[] elements() {
+        return a;
+    }
+    /**
+     * Wraps a given array into an array list of given size.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @param length
+     *            the length of the resulting array list.
+     * @return a new array list of the given size, wrapping the given array.
+     */
+    public static DoubleArrayList wrap(final double a[], final int length) {
+        if (length > a.length)
+            throw new IllegalArgumentException(
+                    "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
+        final DoubleArrayList l = new DoubleArrayList(a, false);
+        l.size = length;
+        return l;
+    }
+    /**
+     * Wraps a given array into an array list.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @return a new array list wrapping the given array.
+     */
+    public static DoubleArrayList wrap(final double a[]) {
+        return wrap(a, a.length);
+    }
+    /**
+     * Ensures that this array list can contain the given number of entries without
+     * resizing.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    public void ensureCapacity(final int capacity) {
+        if (capacity <= a.length || (a == DoubleArrays.DEFAULT_EMPTY_ARRAY && capacity <= DEFAULT_INITIAL_CAPACITY))
+            return;
+        a = DoubleArrays.ensureCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    /**
+     * Grows this array list, ensuring that it can contain the given number of
+     * entries without resizing, and in case increasing the current capacity at
+     * least by a factor of 50%.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    private void grow(int capacity) {
+        if (capacity <= a.length)
+            return;
+        if (a != DoubleArrays.DEFAULT_EMPTY_ARRAY)
+            capacity = (int) Math.max(
+                    Math.min((long) a.length + (a.length >> 1), it.unimi.dsi.fastutil.Arrays.MAX_ARRAY_SIZE), capacity);
+        else if (capacity < DEFAULT_INITIAL_CAPACITY)
+            capacity = DEFAULT_INITIAL_CAPACITY;
+        a = DoubleArrays.forceCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    @Override
+    public void add(final int index, final double k) {
+        ensureIndex(index);
+        grow(size + 1);
+        if (index != size)
+            System.arraycopy(a, index, a, index + 1, size - index);
+        a[index] = k;
+        size++;
+        assert size <= a.length;
+    }
+    @Override
+    public boolean add(final double k) {
+        grow(size + 1);
+        a[size++] = k;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public double getDouble(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        return a[index];
+    }
+    @Override
+    public int indexOf(final double k) {
+        for (int i = 0; i < size; i++)
+            if ((Double.doubleToLongBits(k) == Double.doubleToLongBits(a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public int lastIndexOf(final double k) {
+        for (int i = size; i-- != 0;)
+            if ((Double.doubleToLongBits(k) == Double.doubleToLongBits(a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public double removeDouble(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        final double old = a[index];
+        size--;
+        if (index != size)
+            System.arraycopy(a, index + 1, a, index, size - index);
+        assert size <= a.length;
+        return old;
+    }
+    @Override
+    public boolean rem(final double k) {
+        int index = indexOf(k);
+        if (index == -1)
+            return false;
+        removeDouble(index);
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public double set(final int index, final double k) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        double old = a[index];
+        a[index] = k;
+        return old;
+    }
+    @Override
+    public void clear() {
+        size = 0;
+        assert size <= a.length;
+    }
+    @Override
+    public int size() {
+        return size;
+    }
+    @Override
+    public void size(final int size) {
+        if (size > a.length)
+            a = DoubleArrays.forceCapacity(a, size, this.size);
+        if (size > this.size)
+            Arrays.fill(a, this.size, size, (0));
+        this.size = size;
+    }
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+    /**
+     * Trims this array list so that the capacity is equal to the size.
+     *
+     * @see java.util.ArrayList#trimToSize()
+     */
+    public void trim() {
+        trim(0);
+    }
+    /**
+     * Trims the backing array if it is too large.
+     *
+     * If the current array length is smaller than or equal to {@code n}, this
+     * method does nothing. Otherwise, it trims the array length to the maximum
+     * between {@code n} and {@link #size()}.
+     *
+     * <p>
+     * This method is useful when reusing lists. {@linkplain #clear() Clearing a
+     * list} leaves the array length untouched. If you are reusing a list many
+     * times, you can call this method with a typical size to avoid keeping around a
+     * very large array just because of a few large transient lists.
+     *
+     * @param n
+     *            the threshold for the trimming.
+     */
+
+    public void trim(final int n) {
+        // TODO: use Arrays.trim() and preserve type only if necessary
+        if (n >= a.length || size == a.length)
+            return;
+        final double t[] = new double[Math.max(n, size)];
+        System.arraycopy(a, 0, t, 0, size);
+        a = t;
+        assert size <= a.length;
+    }
+    /**
+     * Copies element of this type-specific list into the given array using
+     * optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param a
+     *            the destination array.
+     * @param offset
+     *            the offset into the destination array where to store the first
+     *            element copied.
+     * @param length
+     *            the number of elements to be copied.
+     */
+    @Override
+    public void getElements(final int from, final double[] a, final int offset, final int length) {
+        DoubleArrays.ensureOffsetLength(a, offset, length);
+        System.arraycopy(this.a, from, a, offset, length);
+    }
+    /**
+     * Removes elements of this type-specific list using optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param to
+     *            the end index (exclusive).
+     */
+    @Override
+    public void removeElements(final int from, final int to) {
+        it.unimi.dsi.fastutil.Arrays.ensureFromTo(size, from, to);
+        System.arraycopy(a, to, a, from, size - to);
+        size -= (to - from);
+    }
+    /**
+     * Adds elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to add elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void addElements(final int index, final double a[], final int offset, final int length) {
+        ensureIndex(index);
+        DoubleArrays.ensureOffsetLength(a, offset, length);
+        grow(size + length);
+        System.arraycopy(this.a, index, this.a, index + length, size - index);
+        System.arraycopy(a, offset, this.a, index, length);
+        size += length;
+    }
+    /**
+     * Sets elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to start setting elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void setElements(final int index, final double a[], final int offset, final int length) {
+        ensureIndex(index);
+        DoubleArrays.ensureOffsetLength(a, offset, length);
+        if (index + length > size)
+            throw new IndexOutOfBoundsException(
+                    "End index (" + (index + length) + ") is greater than list size (" + size + ")");
+        System.arraycopy(a, offset, this.a, index, length);
+    }
+    @Override
+    public double[] toArray(double a[]) {
+        if (a == null || a.length < size)
+            a = new double[size];
+        System.arraycopy(this.a, 0, a, 0, size);
+        return a;
+    }
+    @Override
+    public boolean addAll(int index, final DoubleCollection c) {
+        ensureIndex(index);
+        int n = c.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        final DoubleIterator i = c.iterator();
+        size += n;
+        while (n-- != 0)
+            a[index++] = i.nextDouble();
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean addAll(final int index, final DoubleList l) {
+        ensureIndex(index);
+        final int n = l.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        l.getElements(0, a, index, n);
+        size += n;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean removeAll(final DoubleCollection c) {
+        final double[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(a[i]))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        final double[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(Double.valueOf(a[i])))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public DoubleListIterator listIterator(final int index) {
+        ensureIndex(index);
+        return new DoubleListIterator() {
+            int pos = index, last = -1;
+            @Override
+            public boolean hasNext() {
+                return pos < size;
+            }
+            @Override
+            public boolean hasPrevious() {
+                return pos > 0;
+            }
+            @Override
+            public double nextDouble() {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                return a[last = pos++];
+            }
+            @Override
+            public double previousDouble() {
+                if (!hasPrevious())
+                    throw new NoSuchElementException();
+                return a[last = --pos];
+            }
+            @Override
+            public int nextIndex() {
+                return pos;
+            }
+            @Override
+            public int previousIndex() {
+                return pos - 1;
+            }
+            @Override
+            public void add(double k) {
+                DoubleArrayList.this.add(pos++, k);
+                last = -1;
+            }
+            @Override
+            public void set(double k) {
+                if (last == -1)
+                    throw new IllegalStateException();
+                DoubleArrayList.this.set(last, k);
+            }
+            @Override
+            public void remove() {
+                if (last == -1)
+                    throw new IllegalStateException();
+                DoubleArrayList.this.removeDouble(last);
+                /*
+                 * If the last operation was a next(), we are removing an element *before* us,
+                 * and we must decrease pos correspondingly.
+                 */
+                if (last < pos)
+                    pos--;
+                last = -1;
+            }
+        };
+    }
+    @Override
+    public void sort(final DoubleComparator comp) {
+        if (comp == null) {
+            DoubleArrays.stableSort(a, 0, size);
+        } else {
+            DoubleArrays.stableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public void unstableSort(final DoubleComparator comp) {
+        if (comp == null) {
+            DoubleArrays.unstableSort(a, 0, size);
+        } else {
+            DoubleArrays.unstableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public DoubleArrayList clone() {
+        DoubleArrayList c = new DoubleArrayList(size);
+        System.arraycopy(a, 0, c.a, 0, size);
+        c.size = size;
+        return c;
+    }
+    /**
+     * Compares this type-specific array list to another one.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            a type-specific array list.
+     * @return true if the argument contains the same elements of this type-specific
+     *         array list.
+     */
+    public boolean equals(final DoubleArrayList l) {
+        if (l == this)
+            return true;
+        int s = size();
+        if (s != l.size())
+            return false;
+        final double[] a1 = a;
+        final double[] a2 = l.a;
+        while (s-- != 0)
+            if (a1[s] != a2[s])
+                return false;
+        return true;
+    }
+    /**
+     * Compares this array list to another array list.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            an array list.
+     * @return a negative integer, zero, or a positive integer as this list is
+     *         lexicographically less than, equal to, or greater than the argument.
+     */
+
+    public int compareTo(final DoubleArrayList l) {
+        final int s1 = size(), s2 = l.size();
+        final double a1[] = a, a2[] = l.a;
+        double e1, e2;
+        int r, i;
+        for (i = 0; i < s1 && i < s2; i++) {
+            e1 = a1[i];
+            e2 = a2[i];
+            if ((r = (Double.compare((e1), (e2)))) != 0)
+                return r;
+        }
+        return i < s2 ? -1 : (i < s1 ? 1 : 0);
+    }
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        for (int i = 0; i < size; i++)
+            s.writeDouble(a[i]);
+    }
+
+    private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        a = new double[size];
+        for (int i = 0; i < size; i++)
+            a[i] = s.readDouble();
+    }
+}

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
@@ -49,7 +49,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
     /** The initial default capacity of an array list. */
     public static final int DEFAULT_INITIAL_CAPACITY = 10;
     /** The backing array. */
-    protected transient double a[];
+    protected transient double[] a;
     /**
      * The current actual size of the list (never greater than the backing-array
      * length).
@@ -64,7 +64,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      * @param a
      *            the array that will be used to back this array list.
      */
-    protected DoubleArrayList(final double a[], @SuppressWarnings("unused") boolean dummy) {
+    protected DoubleArrayList(final double[] a, @SuppressWarnings("unused") boolean dummy) {
         this.a = a;
     }
     /**
@@ -84,6 +84,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
     }
     /** Creates a new array list with {@link #DEFAULT_INITIAL_CAPACITY} capacity. */
 
+    @Deprecated
     public DoubleArrayList() {
         a = DoubleArrays.DEFAULT_EMPTY_ARRAY; // We delay allocation
     }
@@ -124,7 +125,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      * @param a
      *            an array whose elements will be used to fill the array list.
      */
-    public DoubleArrayList(final double a[]) {
+    public DoubleArrayList(final double[] a) {
         this(a, 0, a.length);
     }
     /**
@@ -137,7 +138,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      * @param length
      *            the number of elements to use.
      */
-    public DoubleArrayList(final double a[], final int offset, final int length) {
+    public DoubleArrayList(final double[] a, final int offset, final int length) {
         this(length);
         System.arraycopy(a, offset, this.a, 0, length);
         size = length;
@@ -172,6 +173,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *
      * @return the backing array.
      */
+    @Deprecated
     public double[] elements() {
         return a;
     }
@@ -189,7 +191,8 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *            the length of the resulting array list.
      * @return a new array list of the given size, wrapping the given array.
      */
-    public static DoubleArrayList wrap(final double a[], final int length) {
+    @Deprecated
+    public static DoubleArrayList wrap(final double[] a, final int length) {
         if (length > a.length)
             throw new IllegalArgumentException(
                     "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
@@ -209,7 +212,8 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *            an array to wrap.
      * @return a new array list wrapping the given array.
      */
-    public static DoubleArrayList wrap(final double a[]) {
+    @Deprecated
+    public static DoubleArrayList wrap(final double[] a) {
         return wrap(a, a.length);
     }
     /**
@@ -247,6 +251,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
         assert size <= a.length;
     }
     @Override
+    @Deprecated
     public void add(final int index, final double k) {
         ensureIndex(index);
         grow(size + 1);
@@ -257,6 +262,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
         assert size <= a.length;
     }
     @Override
+    @Deprecated
     public boolean add(final double k) {
         grow(size + 1);
         a[size++] = k;
@@ -315,15 +321,18 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
         return old;
     }
     @Override
+    @Deprecated
     public void clear() {
         size = 0;
         assert size <= a.length;
     }
     @Override
+    @Deprecated
     public int size() {
         return size;
     }
     @Override
+    @Deprecated
     public void size(final int size) {
         if (size > a.length)
             a = DoubleArrays.forceCapacity(a, size, this.size);
@@ -359,12 +368,12 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      * @param n
      *            the threshold for the trimming.
      */
-
+    @Deprecated
     public void trim(final int n) {
         // TODO: use Arrays.trim() and preserve type only if necessary
         if (n >= a.length || size == a.length)
             return;
-        final double t[] = new double[Math.max(n, size)];
+        final double[] t = new double[Math.max(n, size)];
         System.arraycopy(a, 0, t, 0, size);
         a = t;
         assert size <= a.length;
@@ -397,6 +406,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *            the end index (exclusive).
      */
     @Override
+    @Deprecated
     public void removeElements(final int from, final int to) {
         it.unimi.dsi.fastutil.Arrays.ensureFromTo(size, from, to);
         System.arraycopy(a, to, a, from, size - to);
@@ -415,7 +425,8 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *            the number of elements to add.
      */
     @Override
-    public void addElements(final int index, final double a[], final int offset, final int length) {
+    @Deprecated
+    public void addElements(final int index, final double[] a, final int offset, final int length) {
         ensureIndex(index);
         DoubleArrays.ensureOffsetLength(a, offset, length);
         grow(size + length);
@@ -423,6 +434,13 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
         System.arraycopy(a, offset, this.a, index, length);
         size += length;
     }
+
+    @Override
+    @Deprecated
+    public void addElements(final int index, final double a[]) {
+        addElements(index, a, 0, a.length);
+    }
+
     /**
      * Sets elements to this type-specific list using optimized system calls.
      *
@@ -436,7 +454,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
      *            the number of elements to add.
      */
     @Override
-    public void setElements(final int index, final double a[], final int offset, final int length) {
+    public void setElements(final int index, final double[] a, final int offset, final int length) {
         ensureIndex(index);
         DoubleArrays.ensureOffsetLength(a, offset, length);
         if (index + length > size)
@@ -445,7 +463,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
         System.arraycopy(a, offset, this.a, index, length);
     }
     @Override
-    public double[] toArray(double a[]) {
+    public double[] toArray(double[] a) {
         if (a == null || a.length < size)
             a = new double[size];
         System.arraycopy(this.a, 0, a, 0, size);
@@ -625,7 +643,7 @@ public class DoubleArrayList extends AbstractDoubleList implements RandomAccess,
 
     public int compareTo(final DoubleArrayList l) {
         final int s1 = size(), s2 = l.size();
-        final double a1[] = a, a2[] = l.a;
+        final double[] a1 = a, a2 = l.a;
         double e1, e2;
         int r, i;
         for (i = 0; i < s1 && i < s2; i++) {

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
@@ -1,4 +1,8 @@
 /*
+ * This file was originally part of https://github.com/vigna/fastutil and was
+ * modified for the specific use case in chartfx by removing all unused
+ * functionality.
+ *
  * Copyright (C) 2002-2020 Sebastiano Vigna
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/DoubleArrayList.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.RandomAccess;
 import java.util.function.DoubleConsumer;
+import java.util.stream.DoubleStream;
 
 /**
  * A type-specific array-based list; provides some additional methods that use
@@ -59,6 +60,10 @@ public class DoubleArrayList implements RandomAccess, Cloneable, java.io.Seriali
         for (int i = 0; i < size; i++) {
             consumer.accept(a[i]);
         }
+    }
+
+    public DoubleStream stream() {
+        return Arrays.stream(a, 0, size);
     }
 
     protected void ensureIndex(final int index) {

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
@@ -49,7 +49,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
     /** The initial default capacity of an array list. */
     public static final int DEFAULT_INITIAL_CAPACITY = 10;
     /** The backing array. */
-    protected transient float a[];
+    protected transient float[] a;
     /**
      * The current actual size of the list (never greater than the backing-array
      * length).
@@ -64,7 +64,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param a
      *            the array that will be used to back this array list.
      */
-    protected FloatArrayList(final float a[], @SuppressWarnings("unused") boolean dummy) {
+    protected FloatArrayList(final float[] a, @SuppressWarnings("unused") boolean dummy) {
         this.a = a;
     }
     /**
@@ -73,7 +73,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param capacity
      *            the initial capacity of the array list (may be 0).
      */
-
+@Deprecated
     public FloatArrayList(final int capacity) {
         if (capacity < 0)
             throw new IllegalArgumentException("Initial capacity (" + capacity + ") is negative");
@@ -124,7 +124,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param a
      *            an array whose elements will be used to fill the array list.
      */
-    public FloatArrayList(final float a[]) {
+    public FloatArrayList(final float[] a) {
         this(a, 0, a.length);
     }
     /**
@@ -137,7 +137,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param length
      *            the number of elements to use.
      */
-    public FloatArrayList(final float a[], final int offset, final int length) {
+    public FloatArrayList(final float[] a, final int offset, final int length) {
         this(length);
         System.arraycopy(a, offset, this.a, 0, length);
         size = length;
@@ -172,6 +172,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      *
      * @return the backing array.
      */
+    @Deprecated
     public float[] elements() {
         return a;
     }
@@ -189,7 +190,8 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      *            the length of the resulting array list.
      * @return a new array list of the given size, wrapping the given array.
      */
-    public static FloatArrayList wrap(final float a[], final int length) {
+    @Deprecated
+    public static FloatArrayList wrap(final float[] a, final int length) {
         if (length > a.length)
             throw new IllegalArgumentException(
                     "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
@@ -209,7 +211,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      *            an array to wrap.
      * @return a new array list wrapping the given array.
      */
-    public static FloatArrayList wrap(final float a[]) {
+    public static FloatArrayList wrap(final float[] a) {
         return wrap(a, a.length);
     }
     /**
@@ -246,7 +248,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
         a = FloatArrays.forceCapacity(a, capacity, size);
         assert size <= a.length;
     }
-    @Override
+    @Override @Deprecated
     public void add(final int index, final float k) {
         ensureIndex(index);
         grow(size + 1);
@@ -256,7 +258,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
         size++;
         assert size <= a.length;
     }
-    @Override
+    @Override @Deprecated
     public boolean add(final float k) {
         grow(size + 1);
         a[size++] = k;
@@ -314,16 +316,17 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
         a[index] = k;
         return old;
     }
-    @Override
+    @Override @Deprecated
     public void clear() {
         size = 0;
         assert size <= a.length;
     }
     @Override
+    @Deprecated
     public int size() {
         return size;
     }
-    @Override
+    @Override @Deprecated
     public void size(final int size) {
         if (size > a.length)
             a = FloatArrays.forceCapacity(a, size, this.size);
@@ -359,12 +362,12 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param n
      *            the threshold for the trimming.
      */
-
+@Deprecated
     public void trim(final int n) {
         // TODO: use Arrays.trim() and preserve type only if necessary
         if (n >= a.length || size == a.length)
             return;
-        final float t[] = new float[Math.max(n, size)];
+        final float[] t = new float[Math.max(n, size)];
         System.arraycopy(a, 0, t, 0, size);
         a = t;
         assert size <= a.length;
@@ -396,7 +399,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param to
      *            the end index (exclusive).
      */
-    @Override
+    @Override @Deprecated
     public void removeElements(final int from, final int to) {
         it.unimi.dsi.fastutil.Arrays.ensureFromTo(size, from, to);
         System.arraycopy(a, to, a, from, size - to);
@@ -414,8 +417,8 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      * @param length
      *            the number of elements to add.
      */
-    @Override
-    public void addElements(final int index, final float a[], final int offset, final int length) {
+    @Override @Deprecated
+    public void addElements(final int index, final float[] a, final int offset, final int length) {
         ensureIndex(index);
         FloatArrays.ensureOffsetLength(a, offset, length);
         grow(size + length);
@@ -436,7 +439,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
      *            the number of elements to add.
      */
     @Override
-    public void setElements(final int index, final float a[], final int offset, final int length) {
+    public void setElements(final int index, final float[] a, final int offset, final int length) {
         ensureIndex(index);
         FloatArrays.ensureOffsetLength(a, offset, length);
         if (index + length > size)
@@ -445,7 +448,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
         System.arraycopy(a, offset, this.a, index, length);
     }
     @Override
-    public float[] toArray(float a[]) {
+    public float[] toArray(float[] a) {
         if (a == null || a.length < size)
             a = new float[size];
         System.arraycopy(this.a, 0, a, 0, size);
@@ -625,7 +628,7 @@ public class FloatArrayList extends AbstractFloatList implements RandomAccess, C
 
     public int compareTo(final FloatArrayList l) {
         final int s1 = size(), s2 = l.size();
-        final float a1[] = a, a2[] = l.a;
+        final float[] a1 = a, a2 = l.a;
         float e1, e2;
         int r, i;
         for (i = 0; i < s1 && i < s2; i++) {

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright (C) 2002-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fair_acc.dataset.spi.fastutil;
+import it.unimi.dsi.fastutil.floats.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.RandomAccess;
+import java.util.NoSuchElementException;
+/**
+ * A type-specific array-based list; provides some additional methods that use
+ * polymorphism to avoid (un)boxing.
+ *
+ * <p>
+ * This class implements a lightweight, fast, open, optimized, reuse-oriented
+ * version of array-based lists. Instances of this class represent a list with
+ * an array that is enlarged as needed when new entries are created (by doubling
+ * its current length), but is <em>never</em> made smaller (even on a
+ * {@link #clear()}). A family of {@linkplain #trim() trimming methods} lets you
+ * control the size of the backing array; this is particularly useful if you
+ * reuse instances of this class. Range checks are equivalent to those of
+ * {@link java.util}'s classes, but they are delayed as much as possible. The
+ * backing array is exposed by the {@link #elements()} method.
+ *
+ * <p>
+ * This class implements the bulk methods {@code removeElements()},
+ * {@code addElements()} and {@code getElements()} using high-performance system
+ * calls (e.g., {@link System#arraycopy(Object,int,Object,int,int)
+ * System.arraycopy()} instead of expensive loops.
+ *
+ * @see java.util.ArrayList
+ */
+public class FloatArrayList extends AbstractFloatList implements RandomAccess, Cloneable, java.io.Serializable {
+    private static final long serialVersionUID = -7046029254386353130L;
+    /** The initial default capacity of an array list. */
+    public static final int DEFAULT_INITIAL_CAPACITY = 10;
+    /** The backing array. */
+    protected transient float a[];
+    /**
+     * The current actual size of the list (never greater than the backing-array
+     * length).
+     */
+    protected int size;
+    /**
+     * Creates a new array list using a given array.
+     *
+     * <p>
+     * This constructor is only meant to be used by the wrapping methods.
+     *
+     * @param a
+     *            the array that will be used to back this array list.
+     */
+    protected FloatArrayList(final float a[], @SuppressWarnings("unused") boolean dummy) {
+        this.a = a;
+    }
+    /**
+     * Creates a new array list with given capacity.
+     *
+     * @param capacity
+     *            the initial capacity of the array list (may be 0).
+     */
+
+    public FloatArrayList(final int capacity) {
+        if (capacity < 0)
+            throw new IllegalArgumentException("Initial capacity (" + capacity + ") is negative");
+        if (capacity == 0)
+            a = FloatArrays.EMPTY_ARRAY;
+        else
+            a = new float[capacity];
+    }
+    /** Creates a new array list with {@link #DEFAULT_INITIAL_CAPACITY} capacity. */
+
+    public FloatArrayList() {
+        a = FloatArrays.DEFAULT_EMPTY_ARRAY; // We delay allocation
+    }
+    /**
+     * Creates a new array list and fills it with a given collection.
+     *
+     * @param c
+     *            a collection that will be used to fill the array list.
+     */
+    public FloatArrayList(final Collection<? extends Float> c) {
+        this(c.size());
+        size = FloatIterators.unwrap(FloatIterators.asFloatIterator(c.iterator()), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific collection.
+     *
+     * @param c
+     *            a type-specific collection that will be used to fill the array
+     *            list.
+     */
+    public FloatArrayList(final FloatCollection c) {
+        this(c.size());
+        size = FloatIterators.unwrap(c.iterator(), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific list.
+     *
+     * @param l
+     *            a type-specific list that will be used to fill the array list.
+     */
+    public FloatArrayList(final FloatList l) {
+        this(l.size());
+        l.getElements(0, a, 0, size = l.size());
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     */
+    public FloatArrayList(final float a[]) {
+        this(a, 0, a.length);
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     * @param offset
+     *            the first element to use.
+     * @param length
+     *            the number of elements to use.
+     */
+    public FloatArrayList(final float a[], final int offset, final int length) {
+        this(length);
+        System.arraycopy(a, offset, this.a, 0, length);
+        size = length;
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by an
+     * iterator..
+     *
+     * @param i
+     *            an iterator whose returned elements will fill the array list.
+     */
+    public FloatArrayList(final Iterator<? extends Float> i) {
+        this();
+        while (i.hasNext())
+            this.add((i.next()).floatValue());
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by a
+     * type-specific iterator..
+     *
+     * @param i
+     *            a type-specific iterator whose returned elements will fill the
+     *            array list.
+     */
+    public FloatArrayList(final FloatIterator i) {
+        this();
+        while (i.hasNext())
+            this.add(i.nextFloat());
+    }
+    /**
+     * Returns the backing array of this list.
+     *
+     * @return the backing array.
+     */
+    public float[] elements() {
+        return a;
+    }
+    /**
+     * Wraps a given array into an array list of given size.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @param length
+     *            the length of the resulting array list.
+     * @return a new array list of the given size, wrapping the given array.
+     */
+    public static FloatArrayList wrap(final float a[], final int length) {
+        if (length > a.length)
+            throw new IllegalArgumentException(
+                    "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
+        final FloatArrayList l = new FloatArrayList(a, false);
+        l.size = length;
+        return l;
+    }
+    /**
+     * Wraps a given array into an array list.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @return a new array list wrapping the given array.
+     */
+    public static FloatArrayList wrap(final float a[]) {
+        return wrap(a, a.length);
+    }
+    /**
+     * Ensures that this array list can contain the given number of entries without
+     * resizing.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    public void ensureCapacity(final int capacity) {
+        if (capacity <= a.length || (a == FloatArrays.DEFAULT_EMPTY_ARRAY && capacity <= DEFAULT_INITIAL_CAPACITY))
+            return;
+        a = FloatArrays.ensureCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    /**
+     * Grows this array list, ensuring that it can contain the given number of
+     * entries without resizing, and in case increasing the current capacity at
+     * least by a factor of 50%.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    private void grow(int capacity) {
+        if (capacity <= a.length)
+            return;
+        if (a != FloatArrays.DEFAULT_EMPTY_ARRAY)
+            capacity = (int) Math.max(
+                    Math.min((long) a.length + (a.length >> 1), it.unimi.dsi.fastutil.Arrays.MAX_ARRAY_SIZE), capacity);
+        else if (capacity < DEFAULT_INITIAL_CAPACITY)
+            capacity = DEFAULT_INITIAL_CAPACITY;
+        a = FloatArrays.forceCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    @Override
+    public void add(final int index, final float k) {
+        ensureIndex(index);
+        grow(size + 1);
+        if (index != size)
+            System.arraycopy(a, index, a, index + 1, size - index);
+        a[index] = k;
+        size++;
+        assert size <= a.length;
+    }
+    @Override
+    public boolean add(final float k) {
+        grow(size + 1);
+        a[size++] = k;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public float getFloat(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        return a[index];
+    }
+    @Override
+    public int indexOf(final float k) {
+        for (int i = 0; i < size; i++)
+            if ((Float.floatToIntBits(k) == Float.floatToIntBits(a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public int lastIndexOf(final float k) {
+        for (int i = size; i-- != 0;)
+            if ((Float.floatToIntBits(k) == Float.floatToIntBits(a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public float removeFloat(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        final float old = a[index];
+        size--;
+        if (index != size)
+            System.arraycopy(a, index + 1, a, index, size - index);
+        assert size <= a.length;
+        return old;
+    }
+    @Override
+    public boolean rem(final float k) {
+        int index = indexOf(k);
+        if (index == -1)
+            return false;
+        removeFloat(index);
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public float set(final int index, final float k) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        float old = a[index];
+        a[index] = k;
+        return old;
+    }
+    @Override
+    public void clear() {
+        size = 0;
+        assert size <= a.length;
+    }
+    @Override
+    public int size() {
+        return size;
+    }
+    @Override
+    public void size(final int size) {
+        if (size > a.length)
+            a = FloatArrays.forceCapacity(a, size, this.size);
+        if (size > this.size)
+            Arrays.fill(a, this.size, size, (0));
+        this.size = size;
+    }
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+    /**
+     * Trims this array list so that the capacity is equal to the size.
+     *
+     * @see java.util.ArrayList#trimToSize()
+     */
+    public void trim() {
+        trim(0);
+    }
+    /**
+     * Trims the backing array if it is too large.
+     *
+     * If the current array length is smaller than or equal to {@code n}, this
+     * method does nothing. Otherwise, it trims the array length to the maximum
+     * between {@code n} and {@link #size()}.
+     *
+     * <p>
+     * This method is useful when reusing lists. {@linkplain #clear() Clearing a
+     * list} leaves the array length untouched. If you are reusing a list many
+     * times, you can call this method with a typical size to avoid keeping around a
+     * very large array just because of a few large transient lists.
+     *
+     * @param n
+     *            the threshold for the trimming.
+     */
+
+    public void trim(final int n) {
+        // TODO: use Arrays.trim() and preserve type only if necessary
+        if (n >= a.length || size == a.length)
+            return;
+        final float t[] = new float[Math.max(n, size)];
+        System.arraycopy(a, 0, t, 0, size);
+        a = t;
+        assert size <= a.length;
+    }
+    /**
+     * Copies element of this type-specific list into the given array using
+     * optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param a
+     *            the destination array.
+     * @param offset
+     *            the offset into the destination array where to store the first
+     *            element copied.
+     * @param length
+     *            the number of elements to be copied.
+     */
+    @Override
+    public void getElements(final int from, final float[] a, final int offset, final int length) {
+        FloatArrays.ensureOffsetLength(a, offset, length);
+        System.arraycopy(this.a, from, a, offset, length);
+    }
+    /**
+     * Removes elements of this type-specific list using optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param to
+     *            the end index (exclusive).
+     */
+    @Override
+    public void removeElements(final int from, final int to) {
+        it.unimi.dsi.fastutil.Arrays.ensureFromTo(size, from, to);
+        System.arraycopy(a, to, a, from, size - to);
+        size -= (to - from);
+    }
+    /**
+     * Adds elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to add elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void addElements(final int index, final float a[], final int offset, final int length) {
+        ensureIndex(index);
+        FloatArrays.ensureOffsetLength(a, offset, length);
+        grow(size + length);
+        System.arraycopy(this.a, index, this.a, index + length, size - index);
+        System.arraycopy(a, offset, this.a, index, length);
+        size += length;
+    }
+    /**
+     * Sets elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to start setting elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void setElements(final int index, final float a[], final int offset, final int length) {
+        ensureIndex(index);
+        FloatArrays.ensureOffsetLength(a, offset, length);
+        if (index + length > size)
+            throw new IndexOutOfBoundsException(
+                    "End index (" + (index + length) + ") is greater than list size (" + size + ")");
+        System.arraycopy(a, offset, this.a, index, length);
+    }
+    @Override
+    public float[] toArray(float a[]) {
+        if (a == null || a.length < size)
+            a = new float[size];
+        System.arraycopy(this.a, 0, a, 0, size);
+        return a;
+    }
+    @Override
+    public boolean addAll(int index, final FloatCollection c) {
+        ensureIndex(index);
+        int n = c.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        final FloatIterator i = c.iterator();
+        size += n;
+        while (n-- != 0)
+            a[index++] = i.nextFloat();
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean addAll(final int index, final FloatList l) {
+        ensureIndex(index);
+        final int n = l.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        l.getElements(0, a, index, n);
+        size += n;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean removeAll(final FloatCollection c) {
+        final float[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(a[i]))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        final float[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(Float.valueOf(a[i])))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public FloatListIterator listIterator(final int index) {
+        ensureIndex(index);
+        return new FloatListIterator() {
+            int pos = index, last = -1;
+            @Override
+            public boolean hasNext() {
+                return pos < size;
+            }
+            @Override
+            public boolean hasPrevious() {
+                return pos > 0;
+            }
+            @Override
+            public float nextFloat() {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                return a[last = pos++];
+            }
+            @Override
+            public float previousFloat() {
+                if (!hasPrevious())
+                    throw new NoSuchElementException();
+                return a[last = --pos];
+            }
+            @Override
+            public int nextIndex() {
+                return pos;
+            }
+            @Override
+            public int previousIndex() {
+                return pos - 1;
+            }
+            @Override
+            public void add(float k) {
+                FloatArrayList.this.add(pos++, k);
+                last = -1;
+            }
+            @Override
+            public void set(float k) {
+                if (last == -1)
+                    throw new IllegalStateException();
+                FloatArrayList.this.set(last, k);
+            }
+            @Override
+            public void remove() {
+                if (last == -1)
+                    throw new IllegalStateException();
+                FloatArrayList.this.removeFloat(last);
+                /*
+                 * If the last operation was a next(), we are removing an element *before* us,
+                 * and we must decrease pos correspondingly.
+                 */
+                if (last < pos)
+                    pos--;
+                last = -1;
+            }
+        };
+    }
+    @Override
+    public void sort(final FloatComparator comp) {
+        if (comp == null) {
+            FloatArrays.stableSort(a, 0, size);
+        } else {
+            FloatArrays.stableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public void unstableSort(final FloatComparator comp) {
+        if (comp == null) {
+            FloatArrays.unstableSort(a, 0, size);
+        } else {
+            FloatArrays.unstableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public FloatArrayList clone() {
+        FloatArrayList c = new FloatArrayList(size);
+        System.arraycopy(a, 0, c.a, 0, size);
+        c.size = size;
+        return c;
+    }
+    /**
+     * Compares this type-specific array list to another one.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            a type-specific array list.
+     * @return true if the argument contains the same elements of this type-specific
+     *         array list.
+     */
+    public boolean equals(final FloatArrayList l) {
+        if (l == this)
+            return true;
+        int s = size();
+        if (s != l.size())
+            return false;
+        final float[] a1 = a;
+        final float[] a2 = l.a;
+        while (s-- != 0)
+            if (a1[s] != a2[s])
+                return false;
+        return true;
+    }
+    /**
+     * Compares this array list to another array list.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            an array list.
+     * @return a negative integer, zero, or a positive integer as this list is
+     *         lexicographically less than, equal to, or greater than the argument.
+     */
+
+    public int compareTo(final FloatArrayList l) {
+        final int s1 = size(), s2 = l.size();
+        final float a1[] = a, a2[] = l.a;
+        float e1, e2;
+        int r, i;
+        for (i = 0; i < s1 && i < s2; i++) {
+            e1 = a1[i];
+            e2 = a2[i];
+            if ((r = (Float.compare((e1), (e2)))) != 0)
+                return r;
+        }
+        return i < s2 ? -1 : (i < s1 ? 1 : 0);
+    }
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        for (int i = 0; i < size; i++)
+            s.writeFloat(a[i]);
+    }
+
+    private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        a = new float[size];
+        for (int i = 0; i < size; i++)
+            a[i] = s.readFloat();
+    }
+}

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/FloatArrayList.java
@@ -1,4 +1,8 @@
 /*
+ * This file was originally part of https://github.com/vigna/fastutil and was
+ * modified for the specific use case in chartfx by removing all unused
+ * functionality.
+ *
  * Copyright (C) 2002-2020 Sebastiano Vigna
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
@@ -49,7 +49,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
     /** The initial default capacity of an array list. */
     public static final int DEFAULT_INITIAL_CAPACITY = 10;
     /** The backing array. */
-    protected transient int a[];
+    protected transient int[] a;
     /**
      * The current actual size of the list (never greater than the backing-array
      * length).
@@ -64,7 +64,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      * @param a
      *            the array that will be used to back this array list.
      */
-    protected IntArrayList(final int a[], @SuppressWarnings("unused") boolean dummy) {
+    protected IntArrayList(final int[] a, @SuppressWarnings("unused") boolean dummy) {
         this.a = a;
     }
     /**
@@ -124,7 +124,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      * @param a
      *            an array whose elements will be used to fill the array list.
      */
-    public IntArrayList(final int a[]) {
+    public IntArrayList(final int[] a) {
         this(a, 0, a.length);
     }
     /**
@@ -137,7 +137,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      * @param length
      *            the number of elements to use.
      */
-    public IntArrayList(final int a[], final int offset, final int length) {
+    public IntArrayList(final int[] a, final int offset, final int length) {
         this(length);
         System.arraycopy(a, offset, this.a, 0, length);
         size = length;
@@ -172,6 +172,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      *
      * @return the backing array.
      */
+    @Deprecated
     public int[] elements() {
         return a;
     }
@@ -189,7 +190,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      *            the length of the resulting array list.
      * @return a new array list of the given size, wrapping the given array.
      */
-    public static IntArrayList wrap(final int a[], final int length) {
+    public static IntArrayList wrap(final int[] a, final int length) {
         if (length > a.length)
             throw new IllegalArgumentException(
                     "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
@@ -209,7 +210,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      *            an array to wrap.
      * @return a new array list wrapping the given array.
      */
-    public static IntArrayList wrap(final int a[]) {
+    public static IntArrayList wrap(final int[] a) {
         return wrap(a, a.length);
     }
     /**
@@ -246,7 +247,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
         a = IntArrays.forceCapacity(a, capacity, size);
         assert size <= a.length;
     }
-    @Override
+    @Override @Deprecated
     public void add(final int index, final int k) {
         ensureIndex(index);
         grow(size + 1);
@@ -256,7 +257,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
         size++;
         assert size <= a.length;
     }
-    @Override
+    @Override @Deprecated
     public boolean add(final int k) {
         grow(size + 1);
         a[size++] = k;
@@ -284,7 +285,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
                 return i;
         return -1;
     }
-    @Override
+    @Override @Deprecated
     public int removeInt(final int index) {
         if (index >= size)
             throw new IndexOutOfBoundsException(
@@ -314,12 +315,12 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
         a[index] = k;
         return old;
     }
-    @Override
+    @Override @Deprecated
     public void clear() {
         size = 0;
         assert size <= a.length;
     }
-    @Override
+    @Override @Deprecated
     public int size() {
         return size;
     }
@@ -331,7 +332,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
             Arrays.fill(a, this.size, size, (0));
         this.size = size;
     }
-    @Override
+    @Override @Deprecated
     public boolean isEmpty() {
         return size == 0;
     }
@@ -364,7 +365,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
         // TODO: use Arrays.trim() and preserve type only if necessary
         if (n >= a.length || size == a.length)
             return;
-        final int t[] = new int[Math.max(n, size)];
+        final int[] t = new int[Math.max(n, size)];
         System.arraycopy(a, 0, t, 0, size);
         a = t;
         assert size <= a.length;
@@ -415,7 +416,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      *            the number of elements to add.
      */
     @Override
-    public void addElements(final int index, final int a[], final int offset, final int length) {
+    public void addElements(final int index, final int[] a, final int offset, final int length) {
         ensureIndex(index);
         IntArrays.ensureOffsetLength(a, offset, length);
         grow(size + length);
@@ -436,7 +437,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
      *            the number of elements to add.
      */
     @Override
-    public void setElements(final int index, final int a[], final int offset, final int length) {
+    public void setElements(final int index, final int[] a, final int offset, final int length) {
         ensureIndex(index);
         IntArrays.ensureOffsetLength(a, offset, length);
         if (index + length > size)
@@ -445,7 +446,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
         System.arraycopy(a, offset, this.a, index, length);
     }
     @Override
-    public int[] toArray(int a[]) {
+    public int[] toArray(int[] a) {
         if (a == null || a.length < size)
             a = new int[size];
         System.arraycopy(this.a, 0, a, 0, size);
@@ -625,7 +626,7 @@ public class IntArrayList extends AbstractIntList implements RandomAccess, Clone
 
     public int compareTo(final IntArrayList l) {
         final int s1 = size(), s2 = l.size();
-        final int a1[] = a, a2[] = l.a;
+        final int[] a1 = a, a2 = l.a;
         int e1, e2;
         int r, i;
         for (i = 0; i < s1 && i < s2; i++) {

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.RandomAccess;
 import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 
 /**
  * A type-specific array-based list; provides some additional methods that use
@@ -60,6 +61,10 @@ public class IntArrayList implements RandomAccess, Cloneable, java.io.Serializab
         for (int i = 0; i < size; i++) {
             consumer.accept(a[i]);
         }
+    }
+
+    public IntStream stream() {
+        return Arrays.stream(a, 0, size);
     }
 
     protected void ensureIndex(final int index) {

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
@@ -1,4 +1,8 @@
 /*
+ * This file was originally part of https://github.com/vigna/fastutil and was
+ * modified for the specific use case in chartfx by removing all unused
+ * functionality.
+ *
  * Copyright (C) 2002-2020 Sebastiano Vigna
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/fastutil/IntArrayList.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright (C) 2002-2020 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fair_acc.dataset.spi.fastutil;
+import it.unimi.dsi.fastutil.ints.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.RandomAccess;
+import java.util.NoSuchElementException;
+/**
+ * A type-specific array-based list; provides some additional methods that use
+ * polymorphism to avoid (un)boxing.
+ *
+ * <p>
+ * This class implements a lightweight, fast, open, optimized, reuse-oriented
+ * version of array-based lists. Instances of this class represent a list with
+ * an array that is enlarged as needed when new entries are created (by doubling
+ * its current length), but is <em>never</em> made smaller (even on a
+ * {@link #clear()}). A family of {@linkplain #trim() trimming methods} lets you
+ * control the size of the backing array; this is particularly useful if you
+ * reuse instances of this class. Range checks are equivalent to those of
+ * {@link java.util}'s classes, but they are delayed as much as possible. The
+ * backing array is exposed by the {@link #elements()} method.
+ *
+ * <p>
+ * This class implements the bulk methods {@code removeElements()},
+ * {@code addElements()} and {@code getElements()} using high-performance system
+ * calls (e.g., {@link System#arraycopy(Object,int,Object,int,int)
+ * System.arraycopy()} instead of expensive loops.
+ *
+ * @see java.util.ArrayList
+ */
+public class IntArrayList extends AbstractIntList implements RandomAccess, Cloneable, java.io.Serializable {
+    private static final long serialVersionUID = -7046029254386353130L;
+    /** The initial default capacity of an array list. */
+    public static final int DEFAULT_INITIAL_CAPACITY = 10;
+    /** The backing array. */
+    protected transient int a[];
+    /**
+     * The current actual size of the list (never greater than the backing-array
+     * length).
+     */
+    protected int size;
+    /**
+     * Creates a new array list using a given array.
+     *
+     * <p>
+     * This constructor is only meant to be used by the wrapping methods.
+     *
+     * @param a
+     *            the array that will be used to back this array list.
+     */
+    protected IntArrayList(final int a[], @SuppressWarnings("unused") boolean dummy) {
+        this.a = a;
+    }
+    /**
+     * Creates a new array list with given capacity.
+     *
+     * @param capacity
+     *            the initial capacity of the array list (may be 0).
+     */
+
+    public IntArrayList(final int capacity) {
+        if (capacity < 0)
+            throw new IllegalArgumentException("Initial capacity (" + capacity + ") is negative");
+        if (capacity == 0)
+            a = IntArrays.EMPTY_ARRAY;
+        else
+            a = new int[capacity];
+    }
+    /** Creates a new array list with {@link #DEFAULT_INITIAL_CAPACITY} capacity. */
+
+    public IntArrayList() {
+        a = IntArrays.DEFAULT_EMPTY_ARRAY; // We delay allocation
+    }
+    /**
+     * Creates a new array list and fills it with a given collection.
+     *
+     * @param c
+     *            a collection that will be used to fill the array list.
+     */
+    public IntArrayList(final Collection<? extends Integer> c) {
+        this(c.size());
+        size = IntIterators.unwrap(IntIterators.asIntIterator(c.iterator()), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific collection.
+     *
+     * @param c
+     *            a type-specific collection that will be used to fill the array
+     *            list.
+     */
+    public IntArrayList(final IntCollection c) {
+        this(c.size());
+        size = IntIterators.unwrap(c.iterator(), a);
+    }
+    /**
+     * Creates a new array list and fills it with a given type-specific list.
+     *
+     * @param l
+     *            a type-specific list that will be used to fill the array list.
+     */
+    public IntArrayList(final IntList l) {
+        this(l.size());
+        l.getElements(0, a, 0, size = l.size());
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     */
+    public IntArrayList(final int a[]) {
+        this(a, 0, a.length);
+    }
+    /**
+     * Creates a new array list and fills it with the elements of a given array.
+     *
+     * @param a
+     *            an array whose elements will be used to fill the array list.
+     * @param offset
+     *            the first element to use.
+     * @param length
+     *            the number of elements to use.
+     */
+    public IntArrayList(final int a[], final int offset, final int length) {
+        this(length);
+        System.arraycopy(a, offset, this.a, 0, length);
+        size = length;
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by an
+     * iterator..
+     *
+     * @param i
+     *            an iterator whose returned elements will fill the array list.
+     */
+    public IntArrayList(final Iterator<? extends Integer> i) {
+        this();
+        while (i.hasNext())
+            this.add((i.next()).intValue());
+    }
+    /**
+     * Creates a new array list and fills it with the elements returned by a
+     * type-specific iterator..
+     *
+     * @param i
+     *            a type-specific iterator whose returned elements will fill the
+     *            array list.
+     */
+    public IntArrayList(final IntIterator i) {
+        this();
+        while (i.hasNext())
+            this.add(i.nextInt());
+    }
+    /**
+     * Returns the backing array of this list.
+     *
+     * @return the backing array.
+     */
+    public int[] elements() {
+        return a;
+    }
+    /**
+     * Wraps a given array into an array list of given size.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @param length
+     *            the length of the resulting array list.
+     * @return a new array list of the given size, wrapping the given array.
+     */
+    public static IntArrayList wrap(final int a[], final int length) {
+        if (length > a.length)
+            throw new IllegalArgumentException(
+                    "The specified length (" + length + ") is greater than the array size (" + a.length + ")");
+        final IntArrayList l = new IntArrayList(a, false);
+        l.size = length;
+        return l;
+    }
+    /**
+     * Wraps a given array into an array list.
+     *
+     * <p>
+     * Note it is guaranteed that the type of the array returned by
+     * {@link #elements()} will be the same (see the comments in the class
+     * documentation).
+     *
+     * @param a
+     *            an array to wrap.
+     * @return a new array list wrapping the given array.
+     */
+    public static IntArrayList wrap(final int a[]) {
+        return wrap(a, a.length);
+    }
+    /**
+     * Ensures that this array list can contain the given number of entries without
+     * resizing.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    public void ensureCapacity(final int capacity) {
+        if (capacity <= a.length || (a == IntArrays.DEFAULT_EMPTY_ARRAY && capacity <= DEFAULT_INITIAL_CAPACITY))
+            return;
+        a = IntArrays.ensureCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    /**
+     * Grows this array list, ensuring that it can contain the given number of
+     * entries without resizing, and in case increasing the current capacity at
+     * least by a factor of 50%.
+     *
+     * @param capacity
+     *            the new minimum capacity for this array list.
+     */
+
+    private void grow(int capacity) {
+        if (capacity <= a.length)
+            return;
+        if (a != IntArrays.DEFAULT_EMPTY_ARRAY)
+            capacity = (int) Math.max(
+                    Math.min((long) a.length + (a.length >> 1), it.unimi.dsi.fastutil.Arrays.MAX_ARRAY_SIZE), capacity);
+        else if (capacity < DEFAULT_INITIAL_CAPACITY)
+            capacity = DEFAULT_INITIAL_CAPACITY;
+        a = IntArrays.forceCapacity(a, capacity, size);
+        assert size <= a.length;
+    }
+    @Override
+    public void add(final int index, final int k) {
+        ensureIndex(index);
+        grow(size + 1);
+        if (index != size)
+            System.arraycopy(a, index, a, index + 1, size - index);
+        a[index] = k;
+        size++;
+        assert size <= a.length;
+    }
+    @Override
+    public boolean add(final int k) {
+        grow(size + 1);
+        a[size++] = k;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public int getInt(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        return a[index];
+    }
+    @Override
+    public int indexOf(final int k) {
+        for (int i = 0; i < size; i++)
+            if (((k) == (a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public int lastIndexOf(final int k) {
+        for (int i = size; i-- != 0;)
+            if (((k) == (a[i])))
+                return i;
+        return -1;
+    }
+    @Override
+    public int removeInt(final int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        final int old = a[index];
+        size--;
+        if (index != size)
+            System.arraycopy(a, index + 1, a, index, size - index);
+        assert size <= a.length;
+        return old;
+    }
+    @Override
+    public boolean rem(final int k) {
+        int index = indexOf(k);
+        if (index == -1)
+            return false;
+        removeInt(index);
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public int set(final int index, final int k) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException(
+                    "Index (" + index + ") is greater than or equal to list size (" + size + ")");
+        int old = a[index];
+        a[index] = k;
+        return old;
+    }
+    @Override
+    public void clear() {
+        size = 0;
+        assert size <= a.length;
+    }
+    @Override
+    public int size() {
+        return size;
+    }
+    @Override
+    public void size(final int size) {
+        if (size > a.length)
+            a = IntArrays.forceCapacity(a, size, this.size);
+        if (size > this.size)
+            Arrays.fill(a, this.size, size, (0));
+        this.size = size;
+    }
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+    /**
+     * Trims this array list so that the capacity is equal to the size.
+     *
+     * @see java.util.ArrayList#trimToSize()
+     */
+    public void trim() {
+        trim(0);
+    }
+    /**
+     * Trims the backing array if it is too large.
+     *
+     * If the current array length is smaller than or equal to {@code n}, this
+     * method does nothing. Otherwise, it trims the array length to the maximum
+     * between {@code n} and {@link #size()}.
+     *
+     * <p>
+     * This method is useful when reusing lists. {@linkplain #clear() Clearing a
+     * list} leaves the array length untouched. If you are reusing a list many
+     * times, you can call this method with a typical size to avoid keeping around a
+     * very large array just because of a few large transient lists.
+     *
+     * @param n
+     *            the threshold for the trimming.
+     */
+
+    public void trim(final int n) {
+        // TODO: use Arrays.trim() and preserve type only if necessary
+        if (n >= a.length || size == a.length)
+            return;
+        final int t[] = new int[Math.max(n, size)];
+        System.arraycopy(a, 0, t, 0, size);
+        a = t;
+        assert size <= a.length;
+    }
+    /**
+     * Copies element of this type-specific list into the given array using
+     * optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param a
+     *            the destination array.
+     * @param offset
+     *            the offset into the destination array where to store the first
+     *            element copied.
+     * @param length
+     *            the number of elements to be copied.
+     */
+    @Override
+    public void getElements(final int from, final int[] a, final int offset, final int length) {
+        IntArrays.ensureOffsetLength(a, offset, length);
+        System.arraycopy(this.a, from, a, offset, length);
+    }
+    /**
+     * Removes elements of this type-specific list using optimized system calls.
+     *
+     * @param from
+     *            the start index (inclusive).
+     * @param to
+     *            the end index (exclusive).
+     */
+    @Override
+    public void removeElements(final int from, final int to) {
+        it.unimi.dsi.fastutil.Arrays.ensureFromTo(size, from, to);
+        System.arraycopy(a, to, a, from, size - to);
+        size -= (to - from);
+    }
+    /**
+     * Adds elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to add elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void addElements(final int index, final int a[], final int offset, final int length) {
+        ensureIndex(index);
+        IntArrays.ensureOffsetLength(a, offset, length);
+        grow(size + length);
+        System.arraycopy(this.a, index, this.a, index + length, size - index);
+        System.arraycopy(a, offset, this.a, index, length);
+        size += length;
+    }
+    /**
+     * Sets elements to this type-specific list using optimized system calls.
+     *
+     * @param index
+     *            the index at which to start setting elements.
+     * @param a
+     *            the array containing the elements.
+     * @param offset
+     *            the offset of the first element to add.
+     * @param length
+     *            the number of elements to add.
+     */
+    @Override
+    public void setElements(final int index, final int a[], final int offset, final int length) {
+        ensureIndex(index);
+        IntArrays.ensureOffsetLength(a, offset, length);
+        if (index + length > size)
+            throw new IndexOutOfBoundsException(
+                    "End index (" + (index + length) + ") is greater than list size (" + size + ")");
+        System.arraycopy(a, offset, this.a, index, length);
+    }
+    @Override
+    public int[] toArray(int a[]) {
+        if (a == null || a.length < size)
+            a = new int[size];
+        System.arraycopy(this.a, 0, a, 0, size);
+        return a;
+    }
+    @Override
+    public boolean addAll(int index, final IntCollection c) {
+        ensureIndex(index);
+        int n = c.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        final IntIterator i = c.iterator();
+        size += n;
+        while (n-- != 0)
+            a[index++] = i.nextInt();
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean addAll(final int index, final IntList l) {
+        ensureIndex(index);
+        final int n = l.size();
+        if (n == 0)
+            return false;
+        grow(size + n);
+        if (index != size)
+            System.arraycopy(a, index, a, index + n, size - index);
+        l.getElements(0, a, index, n);
+        size += n;
+        assert size <= a.length;
+        return true;
+    }
+    @Override
+    public boolean removeAll(final IntCollection c) {
+        final int[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(a[i]))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        final int[] a = this.a;
+        int j = 0;
+        for (int i = 0; i < size; i++)
+            if (!c.contains(Integer.valueOf(a[i])))
+                a[j++] = a[i];
+        final boolean modified = size != j;
+        size = j;
+        return modified;
+    }
+    @Override
+    public IntListIterator listIterator(final int index) {
+        ensureIndex(index);
+        return new IntListIterator() {
+            int pos = index, last = -1;
+            @Override
+            public boolean hasNext() {
+                return pos < size;
+            }
+            @Override
+            public boolean hasPrevious() {
+                return pos > 0;
+            }
+            @Override
+            public int nextInt() {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                return a[last = pos++];
+            }
+            @Override
+            public int previousInt() {
+                if (!hasPrevious())
+                    throw new NoSuchElementException();
+                return a[last = --pos];
+            }
+            @Override
+            public int nextIndex() {
+                return pos;
+            }
+            @Override
+            public int previousIndex() {
+                return pos - 1;
+            }
+            @Override
+            public void add(int k) {
+                IntArrayList.this.add(pos++, k);
+                last = -1;
+            }
+            @Override
+            public void set(int k) {
+                if (last == -1)
+                    throw new IllegalStateException();
+                IntArrayList.this.set(last, k);
+            }
+            @Override
+            public void remove() {
+                if (last == -1)
+                    throw new IllegalStateException();
+                IntArrayList.this.removeInt(last);
+                /*
+                 * If the last operation was a next(), we are removing an element *before* us,
+                 * and we must decrease pos correspondingly.
+                 */
+                if (last < pos)
+                    pos--;
+                last = -1;
+            }
+        };
+    }
+    @Override
+    public void sort(final IntComparator comp) {
+        if (comp == null) {
+            IntArrays.stableSort(a, 0, size);
+        } else {
+            IntArrays.stableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public void unstableSort(final IntComparator comp) {
+        if (comp == null) {
+            IntArrays.unstableSort(a, 0, size);
+        } else {
+            IntArrays.unstableSort(a, 0, size, comp);
+        }
+    }
+    @Override
+    public IntArrayList clone() {
+        IntArrayList c = new IntArrayList(size);
+        System.arraycopy(a, 0, c.a, 0, size);
+        c.size = size;
+        return c;
+    }
+    /**
+     * Compares this type-specific array list to another one.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            a type-specific array list.
+     * @return true if the argument contains the same elements of this type-specific
+     *         array list.
+     */
+    public boolean equals(final IntArrayList l) {
+        if (l == this)
+            return true;
+        int s = size();
+        if (s != l.size())
+            return false;
+        final int[] a1 = a;
+        final int[] a2 = l.a;
+        while (s-- != 0)
+            if (a1[s] != a2[s])
+                return false;
+        return true;
+    }
+    /**
+     * Compares this array list to another array list.
+     *
+     * <p>
+     * This method exists only for sake of efficiency. The implementation inherited
+     * from the abstract implementation would already work.
+     *
+     * @param l
+     *            an array list.
+     * @return a negative integer, zero, or a positive integer as this list is
+     *         lexicographically less than, equal to, or greater than the argument.
+     */
+
+    public int compareTo(final IntArrayList l) {
+        final int s1 = size(), s2 = l.size();
+        final int a1[] = a, a2[] = l.a;
+        int e1, e2;
+        int r, i;
+        for (i = 0; i < s1 && i < s2; i++) {
+            e1 = a1[i];
+            e2 = a2[i];
+            if ((r = (Integer.compare((e1), (e2)))) != 0)
+                return r;
+        }
+        return i < s2 ? -1 : (i < s1 ? 1 : 0);
+    }
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        for (int i = 0; i < size; i++)
+            s.writeInt(a[i]);
+    }
+
+    private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        a = new int[size];
+        for (int i = 0; i < size; i++)
+            a[i] = s.readInt();
+    }
+}

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/utils/StringHashMapList2.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/utils/StringHashMapList2.java
@@ -110,7 +110,9 @@ public class StringHashMapList2 implements Map<Integer, String> {
 
     @Override
     public Set<Integer> keySet() {
-        return new HashSet<>(indices);
+        Set<Integer> set = new HashSet<>();
+        indices.forEach(set::add);
+        return set;
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/utils/StringHashMapList2.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/utils/StringHashMapList2.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import io.fair_acc.dataset.spi.fastutil.IntArrayList;
 
 public class StringHashMapList2 implements Map<Integer, String> {
     private static final long PARALLELISM_THRESHOLD = 1000;

--- a/chartfx-samples/src/main/java/io/fair_acc/chartfx/samples/utils/TestDataSetSource.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/chartfx/samples/utils/TestDataSetSource.java
@@ -26,7 +26,7 @@ import io.fair_acc.math.ArrayUtils;
 import io.fair_acc.math.spectra.Apodization;
 import io.fair_acc.math.spectra.SpectrumTools;
 
-import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import io.fair_acc.dataset.spi.fastutil.FloatArrayList;
 
 /**
  * DataSet source for testing real-time continuous 2D and 3D type data.

--- a/chartfx-samples/src/main/java/io/fair_acc/dataset/samples/FloatToDoubleBenchmarkSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/dataset/samples/FloatToDoubleBenchmarkSample.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import io.fair_acc.dataset.spi.FloatDataSet;
 import io.fair_acc.math.TRandom;
 
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 
 @SuppressWarnings("PMD") // this class tests possible performance bottle-necks
 // not code style/readability


### PR DESCRIPTION
`dataset` currently depends on `it.unimi.dsi:fastutil`, which adds a ~19MB dependency for 3 classes that are actually being used. After icu4j the total size with dependencies (other than JavaFX) is about ~29MB, so removing it would reduce the total size by 2/3 to below 10MB.

> mvn dependency:copy-dependencies -DincludeScope=runtime
> ls -lhS chartfx-chart/target/dependency

```
 19M fastutil-8.3.1.jar
2.2M commons-math3-3.6.1.jar
1.4M controlsfx-11.1.1.jar
1.2M JTransforms-3.1.jar
574K commons-lang3-3.12.0.jar
433K math-master-SNAPSHOT.jar
387K dataset-master-SNAPSHOT.jar
348K ikonli-fontawesome5-pack-11.5.0.jar
228K JLargeArrays-1.5.jar
164K pngj-2.1.0.jar
156K ikonli-fontawesome-pack-11.5.0.jar
 51K slf4j-api-2.0.0-alpha0.jar
 37K ikonli-javafx-11.5.0.jar
 27K annotations-21.0.1.jar
 11K ikonli-core-11.5.0.jar
```

In this PR I shaded the fastutil classes and removed some parts that aren't being used (e.g. sorting). Fastutil uses the Apache v2 license, so it could be used as is.

Do you think it'd be worth using the generator to create more custom-fit implementations?