### PR TITLE
Axis and renderer CSS Styling

### DIFF
--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -13,6 +13,9 @@
     <name>chartfx-chart</name>
     <properties>
         <project.moduleName>io.fair-acc.chartfx</project.moduleName>
+        <sass.version>1.64.2</sass.version>
+        <scss.inputDir>${project.basedir}/src/main/resources/io/fair_acc/chartfx/</scss.inputDir>
+        <css.outputDir>${scss.inputDir}</css.outputDir>
     </properties>
 
     <description>This charting library ${project.artifactId}- is an extension
@@ -93,5 +96,32 @@
             <version>2.1.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin> <!-- Converts Sass files to CSS -->
+                <groupId>us.hebi.sass</groupId>
+                <artifactId>sass-cli-maven-plugin</artifactId>
+                <version>1.0.3</version>
+                <configuration>
+                    <sassVersion>${sass.version}</sassVersion>
+                    <args>
+                        <arg>${scss.inputDir}:${css.outputDir}</arg>
+                        <arg>--no-source-map</arg>
+                    </args>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sass-exec</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
@@ -997,33 +997,4 @@ public abstract class Chart extends Region implements EventSource {
         return group;
     }
 
-    protected static class ChartHBox extends HBox {
-        public ChartHBox(Node... nodes) {
-            super();
-            setAlignment(Pos.CENTER);
-            setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
-            getChildren().addAll(nodes);
-            visibleProperty().addListener((obs, o, n) -> getChildren().forEach(node -> node.setVisible(n)));
-        }
-
-        public ChartHBox(final boolean fill) {
-            this();
-            setFillHeight(fill);
-        }
-    }
-
-    protected static class ChartVBox extends VBox {
-        public ChartVBox(Node... nodes) {
-            super();
-            setAlignment(Pos.CENTER);
-            setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
-            getChildren().addAll(nodes);
-            visibleProperty().addListener((obs, o, n) -> getChildren().forEach(node -> node.setVisible(n)));
-        }
-
-        public ChartVBox(final boolean fill) {
-            this();
-            setFillWidth(fill);
-        }
-    }
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
@@ -123,14 +123,14 @@ public abstract class Chart extends Region implements EventSource {
     protected final Group pluginsArea = Chart.createChildGroup();
 
     // Area where plots get drawn
-    protected final Pane plotBackground = new Pane();
-    protected final HiddenSidesPane plotArea = new HiddenSidesPane();
-    protected final Pane plotForeGround = new Pane();
+    protected final Pane plotBackground = StyleUtil.addStyles(new Pane(), "chart-plot-background");
+    protected final HiddenSidesPane plotArea = StyleUtil.addStyles(new HiddenSidesPane(), "chart-plot-content");
+    protected final Pane plotForeGround = StyleUtil.addStyles(new Pane(), "chart-plot-foreground");
 
     // Outer chart elements
-    protected final ChartPane measurementPane = new ChartPane();
-    protected final ChartPane titleLegendPane = new ChartPane();
-    protected final ChartPane axesAndCanvasPane = new ChartPane();
+    protected final ChartPane measurementPane = StyleUtil.addStyles(new ChartPane(), "chart-measurement-pane");
+    protected final ChartPane titleLegendPane = StyleUtil.addStyles(new ChartPane(),"chart-title-pane", "chart-legend-pane");
+    protected final ChartPane axesAndCanvasPane = StyleUtil.addStyles(new ChartPane(), "chart-content");
 
     // Outer area with hidden toolbars
     protected final HiddenSidesPane menuPane = new HiddenSidesPane();
@@ -149,8 +149,10 @@ public abstract class Chart extends Region implements EventSource {
         //           > canvas foreground
         //           > plugins
         //         > plot background/foreground
-        plotArea.setContent(StyleUtil.addStyles(new PlotAreaPane(getCanvas(), getCanvasForeground(), pluginsArea), "chart-plot-area"));
-        axesAndCanvasPane.addCenter(getPlotBackground(), getPlotArea(), getPlotForeground());
+        StyleUtil.addStyles(this, "chart");
+        var canvasPane = StyleUtil.addStyles(new PlotAreaPane(canvas, canvasForeground, pluginsArea), "chart-plot-area");
+        plotArea.setContent(canvasPane);
+        axesAndCanvasPane.addCenter(plotBackground, plotArea, plotForeGround);
         titleLegendPane.addCenter(axesAndCanvasPane);
         measurementPane.addCenter(titleLegendPane);
         menuPane.setContent(measurementPane);
@@ -168,7 +170,7 @@ public abstract class Chart extends Region implements EventSource {
         getAxes().addListener(axesChangeListenerLocal);
     }
 
-    protected final Label titleLabel = new Label();
+    protected final Label titleLabel = StyleUtil.addStyles(new Label(), "chart-title");
 
     protected final StringProperty title = new StringPropertyBase() {
         @Override
@@ -323,10 +325,6 @@ public abstract class Chart extends Region implements EventSource {
         getCanvasForeground().toFront();
         pluginsArea.toFront();
 
-        plotArea.getStyleClass().setAll("plot-content");
-
-        plotBackground.getStyleClass().setAll("chart-plot-background");
-
         if (!canvas.isCache()) {
             canvas.setCache(true);
             canvas.setCacheHint(CacheHint.QUALITY);
@@ -357,11 +355,6 @@ public abstract class Chart extends Region implements EventSource {
             getLegend().getNode().setVisible(visible);
             getLegend().getNode().setManaged(visible);
         });
-
-        // set CSS stuff
-        titleLabel.getStyleClass().add("chart-title");
-        getStyleClass().add("chart");
-        axesAndCanvasPane.getStyleClass().add("chart-content");
     }
 
     @Override

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import io.fair_acc.chartfx.ui.css.StyleUtil;
+import io.fair_acc.chartfx.ui.layout.TitleLabel;
 import io.fair_acc.chartfx.ui.layout.ChartPane;
 import io.fair_acc.chartfx.ui.layout.PlotAreaPane;
 import io.fair_acc.chartfx.ui.*;
@@ -29,7 +30,6 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.control.Control;
-import javafx.scene.control.Label;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Paint;
 import javafx.util.Duration;
@@ -170,34 +170,7 @@ public abstract class Chart extends Region implements EventSource {
         getAxes().addListener(axesChangeListenerLocal);
     }
 
-    protected final Label titleLabel = StyleUtil.addStyles(new Label(), "chart-title");
-
-    protected final StringProperty title = new StringPropertyBase() {
-        @Override
-        public Object getBean() {
-            return Chart.this;
-        }
-
-        @Override
-        public String getName() {
-            return "title";
-        }
-
-        @Override
-        protected void invalidated() {
-            titleLabel.setText(get());
-        }
-    };
-
-    /**
-     * The side of the chart where the title is displayed default Side.TOP
-     */
-    private final StyleableObjectProperty<Side> titleSide = CSS.createObjectProperty(this, "titleSide", Side.TOP, false,
-            StyleConverter.getEnumConverter(Side.class), (oldVal, newVal) -> {
-                AssertUtils.notNull("Side must not be null", newVal);
-                ChartPane.setSide(titleLabel, newVal);
-                return newVal;
-            }, state.onAction(ChartBits.ChartLayout));
+    protected final TitleLabel titleLabel = StyleUtil.addStyles(new TitleLabel(), "chart-title");
 
     /**
      * The side of the chart where the legend should be displayed default value Side.BOTTOM
@@ -346,7 +319,7 @@ public abstract class Chart extends Region implements EventSource {
         toolBar.registerListener();
         menuPane.setTop(getToolBar());
 
-        getTitleLegendPane().addSide(Side.TOP, titleLabel);
+        getTitleLegendPane().getChildren().add(titleLabel);
 
         legendVisibleProperty().addListener((ch, old, visible) -> {
             if (getLegend() == null) {
@@ -503,15 +476,15 @@ public abstract class Chart extends Region implements EventSource {
     }
 
     public final String getTitle() {
-        return title.get();
+        return titleProperty().get();
+    }
+
+    public final TitleLabel getTitleLabel() {
+        return titleLabel;
     }
 
     public final ChartPane getTitleLegendPane() {
         return titleLegendPane;
-    }
-
-    public final Side getTitleSide() {
-        return titleSide.get();
     }
 
     public final FlowPane getToolBar() {
@@ -730,15 +703,7 @@ public abstract class Chart extends Region implements EventSource {
     }
 
     public final void setTitle(final String value) {
-        title.set(value);
-    }
-
-    public final void setTitleSide(final Side value) {
-        titleSide.set(value);
-    }
-
-    public final void setTitlePaint(final Paint paint) {
-        titleLabel.setTextFill(paint);
+        titleProperty().set(value);
     }
 
     public Chart setToolBarPinned(boolean value) {
@@ -758,11 +723,7 @@ public abstract class Chart extends Region implements EventSource {
     }
 
     public final StringProperty titleProperty() {
-        return title;
-    }
-
-    public final ObjectProperty<Side> titleSideProperty() {
-        return titleSide;
+        return titleLabel.textProperty();
     }
 
     public BooleanProperty toolBarPinnedProperty() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -162,39 +162,12 @@ public class XYChart extends Chart {
     }
 
     /**
-     * Indicates whether horizontal grid lines are visible or not.
-     *
-     * @return horizontalGridLinesVisible property
-     */
-    public final BooleanProperty horizontalGridLinesVisibleProperty() {
-        return gridRenderer.horizontalGridLinesVisibleProperty();
-    }
-
-    /**
-     * Indicates whether horizontal grid lines are visible.
-     *
-     * @return {@code true} if horizontal grid lines are visible else {@code false}.
-     */
-    public final boolean isHorizontalGridLinesVisible() {
-        return horizontalGridLinesVisibleProperty().get();
-    }
-
-    /**
      * whether renderer should use polar coordinates (x -&gt; interpreted as phi, y as radial coordinate)
      *
      * @return true if renderer is plotting in polar coordinates
      */
     public final boolean isPolarPlot() {
         return polarPlotProperty().get();
-    }
-
-    /**
-     * Indicates whether vertical grid lines are visible.
-     *
-     * @return {@code true} if vertical grid lines are visible else {@code false}.
-     */
-    public final boolean isVerticalGridLinesVisible() {
-        return verticalGridLinesVisibleProperty().get();
     }
 
     /**
@@ -211,15 +184,6 @@ public class XYChart extends Chart {
     }
 
     /**
-     * Sets the value of the {@link #verticalGridLinesVisibleProperty()}.
-     *
-     * @param value {@code true} to make vertical lines visible
-     */
-    public final void setHorizontalGridLinesVisible(final boolean value) {
-        horizontalGridLinesVisibleProperty().set(value);
-    }
-
-    /**
      * Sets whether renderer should use polar coordinates (x -&gt; interpreted as phi, y as radial coordinate)
      *
      * @param state true if renderer is parallelising sub-functionalities
@@ -232,15 +196,6 @@ public class XYChart extends Chart {
 
     public void setPolarStepSize(final PolarTickStep step) {
         polarStepSizeProperty().set(step);
-    }
-
-    /**
-     * Sets the value of the {@link #verticalGridLinesVisibleProperty()}.
-     *
-     * @param value {@code true} to make vertical lines visible
-     */
-    public final void setVerticalGridLinesVisible(final boolean value) {
-        verticalGridLinesVisibleProperty().set(value);
     }
 
     @Override
@@ -260,15 +215,6 @@ public class XYChart extends Chart {
         // Update each of the axes
         getAxes().forEach(chartAxis -> updateNumericAxis(chartAxis, getDataSetForAxis(chartAxis)));
 
-    }
-
-    /**
-     * Indicates whether vertical grid lines are visible or not.
-     *
-     * @return verticalGridLinesVisible property
-     */
-    public final BooleanProperty verticalGridLinesVisibleProperty() {
-        return gridRenderer.verticalGridLinesVisibleProperty();
     }
 
     private boolean isDataEmpty() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -91,7 +91,8 @@ public class XYChart extends Chart {
                 gridRenderer.getHorizontalMajorGrid().changeCounterProperty(),
                 gridRenderer.getHorizontalMinorGrid().changeCounterProperty(),
                 gridRenderer.getVerticalMajorGrid().changeCounterProperty(),
-                gridRenderer.getVerticalMinorGrid().changeCounterProperty());
+                gridRenderer.getVerticalMinorGrid().changeCounterProperty(),
+                gridRenderer.drawOnTopProperty());
 
         this.setAnimated(false);
         getRenderers().addListener(this::rendererChanged);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -86,7 +86,7 @@ public class XYChart extends Chart {
             getAxes().add(axis);
         }
 
-        getChildren().add(gridRenderer);
+        styleableNodes.getChildren().add(gridRenderer);
         PropUtil.runOnChange(getBitState().onAction(ChartBits.ChartCanvas),
                 gridRenderer.getHorizontalMajorGrid().changeCounterProperty(),
                 gridRenderer.getHorizontalMinorGrid().changeCounterProperty(),

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -88,16 +88,10 @@ public class XYChart extends Chart {
 
         getChildren().add(0, gridRenderer);
         PropUtil.runOnChange(getBitState().onAction(ChartBits.ChartCanvas),
-                gridRenderer.horizontalGridLinesVisibleProperty(),
-                gridRenderer.verticalGridLinesVisibleProperty(),
-                gridRenderer.getHorizontalMinorGrid().visibleProperty(),
-                gridRenderer.getVerticalMinorGrid().visibleProperty(),
-                gridRenderer.drawOnTopProperty(),
                 gridRenderer.getHorizontalMajorGrid().changeCounterProperty(),
-                gridRenderer.getVerticalMajorGrid().changeCounterProperty(),
                 gridRenderer.getHorizontalMinorGrid().changeCounterProperty(),
-                gridRenderer.getVerticalMinorGrid().changeCounterProperty()
-        );
+                gridRenderer.getVerticalMajorGrid().changeCounterProperty(),
+                gridRenderer.getVerticalMinorGrid().changeCounterProperty());
 
         this.setAnimated(false);
         getRenderers().addListener(this::rendererChanged);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -86,7 +86,7 @@ public class XYChart extends Chart {
             getAxes().add(axis);
         }
 
-        getChildren().add(0, gridRenderer);
+        getChildren().add(gridRenderer);
         PropUtil.runOnChange(getBitState().onAction(ChartBits.ChartCanvas),
                 gridRenderer.getHorizontalMajorGrid().changeCounterProperty(),
                 gridRenderer.getHorizontalMinorGrid().changeCounterProperty(),

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/Axis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/Axis.java
@@ -2,6 +2,8 @@ package io.fair_acc.chartfx.axes;
 
 import java.util.List;
 
+import io.fair_acc.chartfx.ui.css.LineStyle;
+import io.fair_acc.chartfx.ui.css.TextStyle;
 import io.fair_acc.dataset.events.BitState;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -112,17 +114,27 @@ public interface Axis extends AxisDescription {
      */
     Side getSide();
 
-    /**
-     * @return the fill for all tick labels
-     */
-    Paint getTickLabelFill();
-
-    /**
-     * @return the font for all tick labels
-     */
-    Font getTickLabelFont();
-
     StringConverter<Number> getTickLabelFormatter();
+
+    /**
+     * @return the style for the axis label
+     */
+    TextStyle getAxisLabel();
+
+    /**
+     * @return the style for all tick labels
+     */
+    TextStyle getTickLabelStyle();
+
+    /**
+     * @return the style for all major tick marks
+     */
+    LineStyle getMajorTickStyle();
+
+    /**
+     * @return the style for all minor tick marks
+     */
+    LineStyle getMinorTickStyle();
 
     /**
      * @return the gap between the tick mark lines and the chart canvas

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
@@ -40,6 +40,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     protected static final double MAX_NARROW_FONT_SCALE = 1.0;
     protected static final double MIN_TICK_GAP = 1.0;
     private final transient Canvas canvas = new ResizableCanvas();
+    private boolean drawAxisLabel;
     private boolean shiftLabels;
     protected boolean labelOverlap;
     protected double scaleFont = 1.0;
@@ -426,6 +427,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         scaleFont = 1.0;
         maxLabelHeight = 0;
         maxLabelWidth = 0;
+        drawAxisLabel = false;
         shiftLabels = false;
         labelOverlap = false;
 
@@ -460,6 +462,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
         // Size of the axis label w/ units
         final double axisLabelSize = getAxisLabelSize();
+        drawAxisLabel = axisLabelSize > 0;
 
         // Remove gaps between empty space
         final double tickLabelGap = tickLabelSize <= 0 ? 0 : getTickLabelGap();
@@ -525,7 +528,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     private double getAxisLabelSize() {
         final Text axisLabel = getAxisLabel();
-        if (!PropUtil.isNullOrEmpty(axisLabel.getText())) {
+        if (axisLabel.isVisible() && !PropUtil.isNullOrEmpty(axisLabel.getText())) {
             var bounds = axisLabel.getBoundsInParent();
             return getSide().isHorizontal() ? bounds.getHeight() : bounds.getWidth();
         }
@@ -684,6 +687,10 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     protected void drawAxisLabel(final GraphicsContext gc, final double axisWidth, final double axisHeight,
                                  final TextStyle axisLabel, final double tickLength) {
+
+        if (!drawAxisLabel) {
+            return;
+        }
 
         // relative positioning of the label based on the text alignment
         // TODO: why tickLabelGap instead of axisLabelGap?

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
@@ -17,9 +17,7 @@ import javafx.geometry.VPos;
 import javafx.scene.CacheHint;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
@@ -83,11 +81,6 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     };
 
     protected AbstractAxis() {
-        super();
-        // Can we remove these? Axes without a chart don't work anymore.
-        VBox.setVgrow(this, Priority.ALWAYS);
-        HBox.setHgrow(this, Priority.ALWAYS);
-
         // Canvas settings
         setMouseTransparent(false);
         setPickOnBounds(true);
@@ -100,15 +93,11 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         getChildren().add(canvas);
 
         // set default axis title/label alignment
-        updateTickLabelAlignment();
-        updateAxisLabelAlignment();
-        sideProperty().addListener((ch, o, n) -> {
-            updateAxisLabelAlignment();
-            updateTickLabelAlignment();
-        });
-        tickLabelRotationProperty().addListener((ch, o, n) -> {
-            updateTickLabelAlignment();
-        });
+        PropUtil.initAndRunOnChange(this::updateAxisLabelAlignment,
+                sideProperty());
+        PropUtil.initAndRunOnChange(this::updateTickLabelAlignment,
+                sideProperty(),
+                getTickLabelStyle().rotateProperty());
     }
 
     protected AbstractAxis(final double lowerBound, final double upperBound) {
@@ -920,7 +909,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     }
 
-    protected double measureTickMarkLength(final Double major) {
+    protected double measureTickMarkLength(final double major) {
         // N.B. this is a known performance hot-spot -> start optimisation here
         tmpTickMark.setValue(major, getTickMarkLabel(major));
         return getSide().isHorizontal() ? tmpTickMark.getWidth() : tmpTickMark.getHeight();

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
@@ -3,9 +3,7 @@ package io.fair_acc.chartfx.axes.spi;
 import java.util.List;
 import java.util.Objects;
 
-import io.fair_acc.chartfx.ui.css.LineStyle;
-import io.fair_acc.chartfx.ui.css.StyleUtil;
-import io.fair_acc.chartfx.ui.css.TextStyle;
+import io.fair_acc.chartfx.ui.css.*;
 import io.fair_acc.chartfx.ui.layout.ChartPane;
 import io.fair_acc.chartfx.utils.PropUtil;
 import io.fair_acc.dataset.events.BitState;
@@ -26,7 +24,6 @@ import javafx.util.StringConverter;
 import io.fair_acc.chartfx.Chart;
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.axes.AxisLabelOverlapPolicy;
-import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
 import io.fair_acc.chartfx.ui.geometry.Side;
 
 /**
@@ -43,13 +40,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
      */
     public AbstractAxisParameter() {
         super();
-        // Styles changes that can be removed after moving the styling to sub-nodes
-        tickLabelStyle.rotateProperty().bindBidirectional(tickLabelRotation);
-        tickLabelStyle.fontProperty().bindBidirectional(tickLabelFont);
-        tickLabelStyle.fillProperty().bindBidirectional(tickLabelFill);
-        axisLabel.textAlignmentProperty().bindBidirectional(axisLabelTextAlignmentProperty()); // NOPMD
-
-        axisPadding.addListener(state.onPropChange(ChartBits.AxisLayout)::set);
 
         // Properties that may be relevant to the layout and must always at least redraw the canvas
         PropUtil.runOnChange(invalidateLayout = state.onAction(ChartBits.AxisLayout, ChartBits.AxisCanvas),
@@ -189,15 +179,11 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
      * Note that we can use the tick label style as a temporary node for getting the font metrics w/ the correct style.
      * Unmanaged nodes do not trigger a re-layout of the parent, but invisible text still computes valid font metrics.
      */
-    private final transient LineStyle majorTickStyle = new LineStyle("axis-tick-mark");
-    private final transient LineStyle minorTickStyle = new LineStyle("axis-minor-tick-mark");
-    private final transient TextStyle tickLabelStyle = new TextStyle("axis-tick-label");
-    private final transient TextStyle axisLabel = new TextStyle("axis-label");
-
-    {
-        StyleUtil.addStyles(this, "axis");
-        getChildren().addAll(axisLabel, tickLabelStyle, majorTickStyle, minorTickStyle);
-    }
+    private final StyleGroup styles = new StyleGroup(this, "axis");
+    private final transient LineStyle majorTickStyle = styles.newLineStyle("axis-tick-mark");
+    private final transient LineStyle minorTickStyle =  styles.newLineStyle("axis-minor-tick-mark");
+    private final transient TextStyle tickLabelStyle =  styles.newTextStyle("axis-tick-label");
+    private final transient TextStyle axisLabel =  styles.newTextStyle("axis-label");
 
     protected final transient DoubleArrayList majorTickMarkValues = new DoubleArrayList();
     protected final transient DoubleArrayList minorTickMarkValues = new DoubleArrayList();
@@ -234,7 +220,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * axis label alignment
      */
-    private final transient StyleableObjectProperty<TextAlignment> axisLabelTextAlignment = CSS.createObjectProperty(this, "axisLabelTextAlignment", TextAlignment.CENTER, StyleConverter.getEnumConverter(TextAlignment.class));
+    private final transient ObjectProperty<TextAlignment> axisLabelTextAlignment = axisLabel.textAlignmentProperty();
 
     /**
      * The axis label
@@ -244,7 +230,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * true if tick marks should be displayed
      */
-    private final transient StyleableBooleanProperty tickMarkVisible = CSS.createBooleanProperty(this, "tickMarkVisible", true);
+    private final transient BooleanProperty tickMarkVisible = majorTickStyle.visibleProperty();
 
     /**
      * true if tick mark labels should be displayed
@@ -279,12 +265,12 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * The font for all tick labels
      */
-    private final transient StyleableObjectProperty<Font> tickLabelFont = CSS.createObjectProperty(this, "tickLabelFont", Font.font("System", 8), false, StyleConverter.getFontConverter(), null);
+    private final transient ObjectProperty<Font> tickLabelFont = tickLabelStyle.fontProperty();
 
     /**
      * The fill for all tick labels
      */
-    private final transient StyleableObjectProperty<Paint> tickLabelFill = CSS.createObjectProperty(this, "tickLabelFill", Color.BLACK, StyleConverter.getPaintConverter());
+    private final transient ObjectProperty<Paint> tickLabelFill = tickLabelStyle.fillProperty();
 
     /**
      * The gap between tick marks and the canvas area
@@ -324,12 +310,12 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * Rotation in degrees of tick mark labels from their normal horizontal.
      */
-    protected final transient StyleableDoubleProperty tickLabelRotation = CSS.createDoubleProperty(this, "tickLabelRotation", 0.0);
+    protected final transient DoubleProperty tickLabelRotation = tickLabelStyle.rotateProperty();
 
     /**
      * true if minor tick marks should be displayed
      */
-    private final transient StyleableBooleanProperty minorTickVisible = CSS.createBooleanProperty(this, "minorTickVisible", true);
+    private final transient BooleanProperty minorTickVisible = minorTickStyle.visibleProperty();
 
     /**
      * The scale factor from data units to visual units

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
@@ -235,7 +235,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * true if tick mark labels should be displayed
      */
-    private final transient StyleableBooleanProperty tickLabelsVisible = CSS.createBooleanProperty(this, "tickLabelsVisible", true);
+    private final transient BooleanProperty tickLabelsVisible = tickLabelStyle.visibleProperty();
 
     /**
      * The length of tick mark lines

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
@@ -204,8 +204,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
      * The side of the plot which this axis is being drawn on default axis orientation is BOTTOM, can be set latter to
      * another side
      */
-    private final transient StyleableObjectProperty<Side> side = CSS.createEnumPropertyWithPseudoclasses(this, "side", Side.BOTTOM, false, Side.class, null,
-            () -> ChartPane.setSide(this, getSide()));
+    private final transient StyleableObjectProperty<Side> side = CSS.createSideProperty(this, Side.BOTTOM);
 
     /**
      * The side of the plot which this axis is being drawn on

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/legend/Legend.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/legend/Legend.java
@@ -3,12 +3,17 @@ package io.fair_acc.chartfx.legend;
 import java.util.List;
 
 import io.fair_acc.chartfx.renderer.Renderer;
+import io.fair_acc.chartfx.ui.geometry.Side;
 import io.fair_acc.dataset.DataSet;
 import javafx.scene.Node;
 
 public interface Legend {
 
     Node getNode();
+
+    Side getSide();
+
+    void setSide(Side side);
 
     boolean isVertical();
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/legend/spi/DefaultLegend.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/legend/spi/DefaultLegend.java
@@ -51,8 +51,7 @@ public class DefaultLegend extends FlowPane implements Legend {
     private final ObservableList<LegendItem> items = FXCollections.observableArrayList();
 
     public DefaultLegend() {
-        getStyleClass().setAll("chart-legend");
-        managedProperty().bind(visibleProperty().and(Bindings.size(items).isNotEqualTo(0)));
+        StyleUtil.addStyles(this, "chart-legend");
         items.addListener((ListChangeListener<LegendItem>) c -> getChildren().setAll(items));
         PropUtil.runOnChange(this::applyCss, sideProperty());
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractContourDataSetRendererParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractContourDataSetRendererParameter.java
@@ -13,7 +13,7 @@ import io.fair_acc.chartfx.renderer.datareduction.ReductionType;
 import io.fair_acc.chartfx.renderer.spi.utils.ColorGradient;
 
 public abstract class AbstractContourDataSetRendererParameter<R extends AbstractContourDataSetRendererParameter<R>>
-        extends AbstractPointReductionManagment<R> {
+        extends AbstractPointReducingRenderer<R> {
     private final BooleanProperty altImplementation = new SimpleBooleanProperty(this, "altImplementation", false);
     private final IntegerProperty reductionFactorX = new SimpleIntegerProperty(this, "reductionFactorX", 2);
     private final IntegerProperty reductionFactorY = new SimpleIntegerProperty(this, "reductionFactorY", 2);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractErrorDataSetRendererParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractErrorDataSetRendererParameter.java
@@ -33,7 +33,7 @@ import io.fair_acc.dataset.utils.AssertUtils;
 @SuppressWarnings({ "PMD.TooManyMethods", "PMD.TooManyFields", "PMD.ExcessivePublicCount" }) // designated purpose of
 // this class
 public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractErrorDataSetRendererParameter<R>>
-        extends AbstractPointReductionManagment<R> {
+        extends AbstractPointReducingRenderer<R> {
     // intensity fading factor per stage
     protected static final double DEFAULT_HISTORY_INTENSITY_FADING = 0.65;
     private final ObjectProperty<ErrorStyle> errorStyle = new SimpleObjectProperty<>(this, "errorStyle",

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractErrorDataSetRendererParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractErrorDataSetRendererParameter.java
@@ -1,8 +1,12 @@
 package io.fair_acc.chartfx.renderer.spi;
 
+import java.util.List;
 import java.util.Objects;
 
+import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
+import io.fair_acc.chartfx.ui.css.StyleUtil;
 import io.fair_acc.chartfx.utils.PropUtil;
+import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
@@ -22,6 +26,8 @@ import io.fair_acc.chartfx.renderer.datareduction.MaxDataReducer;
 import io.fair_acc.chartfx.renderer.datareduction.RamanDouglasPeukerDataReducer;
 import io.fair_acc.chartfx.renderer.datareduction.VisvalingamMaheswariWhyattDataReducer;
 import io.fair_acc.dataset.utils.AssertUtils;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
 
 /**
  * simple class to move the various parameters out of the class containing the algorithms uses the shadow field pattern
@@ -36,33 +42,34 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
         extends AbstractPointReducingRenderer<R> {
     // intensity fading factor per stage
     protected static final double DEFAULT_HISTORY_INTENSITY_FADING = 0.65;
-    private final ObjectProperty<ErrorStyle> errorStyle = new SimpleObjectProperty<>(this, "errorStyle",
-            ErrorStyle.ERRORCOMBO);
+    private final ObjectProperty<ErrorStyle> errorStyle = css().createEnumPropertyWithPseudoclasses(this, "errorStyle",
+            ErrorStyle.ERRORCOMBO, ErrorStyle.class);
     private final ObjectProperty<RendererDataReducer> rendererDataReducer = new SimpleObjectProperty<>(this,
             "rendererDataReducer", new DefaultDataReducer());
 
-    private final IntegerProperty dashSize = new SimpleIntegerProperty(this, "dashSize", 3);
-    private final DoubleProperty markerSize = new SimpleDoubleProperty(this, "markerSize", 1.5);
-    private final BooleanProperty drawMarker = new SimpleBooleanProperty(this, "drawMarker", true);
-    private final ObjectProperty<LineStyle> polyLineStyle = new SimpleObjectProperty<>(this, "polyLineStyle",
-            LineStyle.NORMAL);
+    private final IntegerProperty dashSize = css().createIntegerProperty(this, "dashSize", 3);
+    private final DoubleProperty markerSize = css().createDoubleProperty(this, "markerSize", 1.5);
+    private final BooleanProperty drawMarker = css().createBooleanProperty(this, "drawMarker", true);
+    private final ObjectProperty<LineStyle> polyLineStyle = css().createEnumPropertyWithPseudoclasses(this, "polyLineStyle",
+            LineStyle.NORMAL, LineStyle.class);
     private final BooleanProperty drawChartDataSets = new SimpleBooleanProperty(this, "drawChartDataSets", true);
-    private final BooleanProperty drawBars = new SimpleBooleanProperty(this, "drawBars", false);
-    private final BooleanProperty shiftBar = new SimpleBooleanProperty(this, "shiftBar", true);
-    private final IntegerProperty shiftBarOffset = new SimpleIntegerProperty(this, "shiftBarOffset", 3);
-    private final BooleanProperty dynamicBarWidth = new SimpleBooleanProperty(this, "dynamicBarWidth", true);
-    private final DoubleProperty barWidthPercentage = new SimpleDoubleProperty(this, "barWidthPercentage", 70.0);
-    private final IntegerProperty barWidth = new SimpleIntegerProperty(this, "barWidth", 5);
-    private final DoubleProperty intensityFading = new SimpleDoubleProperty(this, "intensityFading",
+    private final BooleanProperty drawBars = css().createBooleanProperty(this, "drawBars", false);
+    private final BooleanProperty shiftBar = css().createBooleanProperty(this, "shiftBar", true);
+    private final IntegerProperty shiftBarOffset = css().createIntegerProperty(this, "shiftBarOffset", 3);
+    private final BooleanProperty dynamicBarWidth = css().createBooleanProperty(this, "dynamicBarWidth", true);
+    private final DoubleProperty barWidthPercentage = css().createDoubleProperty(this, "barWidthPercentage", 70.0);
+    private final IntegerProperty barWidth = css().createIntegerProperty(this, "barWidth", 5);
+    private final DoubleProperty intensityFading = css().createDoubleProperty(this, "intensityFading",
             AbstractErrorDataSetRendererParameter.DEFAULT_HISTORY_INTENSITY_FADING);
-    private final BooleanProperty drawBubbles = new SimpleBooleanProperty(this, "drawBubbles", false);
-    private final BooleanProperty allowNaNs = new SimpleBooleanProperty(this, "allowNaNs", false);
+    private final BooleanProperty drawBubbles = css().createBooleanProperty(this, "drawBubbles", false);
+    private final BooleanProperty allowNans = css().createBooleanProperty(this, "allowNans", false);
 
     /**
      * 
      */
     public AbstractErrorDataSetRendererParameter() {
         super();
+        StyleUtil.addStyles(this,"error-dataset-renderer");
         PropUtil.runOnChange(this::invalidateCanvas,
                 errorStyle,
                 rendererDataReducer,
@@ -79,17 +86,14 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
                 barWidth,
                 intensityFading,
                 drawBubbles,
-                allowNaNs);
-    }
-
-    protected void invalidateCanvas() {
+                allowNans);
     }
 
     /**
      * @return the drawBubbles property
      */
     public BooleanProperty allowNaNsProperty() {
-        return allowNaNs;
+        return allowNans;
     }
 
     public DoubleProperty barWidthPercentageProperty() {
@@ -178,7 +182,9 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
      * @see ErrorDataSetRenderer#setErrorType(ErrorStyle style) for details
      */
     public ErrorStyle getErrorType() {
-        return errorStyleProperty().get();
+        // TODO: figure out why 'none' in CSS maps to null
+        var type = errorStyleProperty().get();
+        return type == null ? ErrorStyle.NONE : type;
     }
 
     /**
@@ -542,4 +548,12 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
 
         return getThis();
     }
+
+    @Override
+    protected CssPropertyFactory<AbstractRenderer<?>> css() {
+        return CSS;
+    }
+
+    private static final CssPropertyFactory<AbstractRenderer<?>> CSS = new CssPropertyFactory<>(AbstractPointReducingRenderer.getClassCssMetaData());
+
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractPointReducingRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractPointReducingRenderer.java
@@ -1,25 +1,28 @@
 package io.fair_acc.chartfx.renderer.spi;
 
+import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleIntegerProperty;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
 
-public abstract class AbstractPointReductionManagment<R extends AbstractPointReductionManagment<R>>
-        extends AbstractDataSetManagement<R> {
-    private final ReadOnlyBooleanWrapper actualPointReduction = new ReadOnlyBooleanWrapper(this, "actualPointReduction",
-            true);
-    private final BooleanProperty assumeSortedData = new SimpleBooleanProperty(this, "assumeSortedData", true);
-    private final IntegerProperty minRequiredReductionSize = new SimpleIntegerProperty(this, "minRequiredReductionSize",
-            5);
-    private final BooleanProperty parallelImplementation = new SimpleBooleanProperty(this, "parallelImplementation",
-            true);
-    private final BooleanProperty pointReduction = new SimpleBooleanProperty(this, "pointReduction", true);
+import java.util.List;
 
-    public AbstractPointReductionManagment() {
+public abstract class AbstractPointReducingRenderer<R extends AbstractPointReducingRenderer<R>>
+        extends AbstractRenderer<R> {
+    private final ReadOnlyBooleanWrapper actualPointReduction = registerCanvasProp(new ReadOnlyBooleanWrapper(this, "actualPointReduction",
+            true));
+    private final BooleanProperty assumeSortedData = CSS.createBooleanProperty(this, "assumeSortedData", true);
+    private final IntegerProperty minRequiredReductionSize = registerCanvasProp(CSS.createIntegerProperty(this, "minRequiredReductionSize",
+            5));
+    private final BooleanProperty parallelImplementation = registerCanvasProp(CSS.createBooleanProperty(this, "parallelImplementation",
+            true));
+    private final BooleanProperty pointReduction = CSS.createBooleanProperty(this, "pointReduction", true);
+
+    public AbstractPointReducingRenderer() {
         super();
         actualPointReduction.bind(Bindings.and(pointReduction, assumeSortedData));
     }
@@ -155,4 +158,16 @@ public abstract class AbstractPointReductionManagment<R extends AbstractPointRed
         pointReduction.set(state);
         return getThis();
     }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return getClassCssMetaData();
+    }
+
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return CSS.getCssMetaData();
+    }
+
+    private static final CssPropertyFactory<AbstractRenderer<?>> CSS = new CssPropertyFactory<>(AbstractRenderer.getClassCssMetaData());
+
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractPointReducingRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractPointReducingRenderer.java
@@ -1,6 +1,7 @@
 package io.fair_acc.chartfx.renderer.spi;
 
 import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
+import io.fair_acc.chartfx.ui.css.StyleUtil;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
@@ -15,12 +16,12 @@ public abstract class AbstractPointReducingRenderer<R extends AbstractPointReduc
         extends AbstractRenderer<R> {
     private final ReadOnlyBooleanWrapper actualPointReduction = registerCanvasProp(new ReadOnlyBooleanWrapper(this, "actualPointReduction",
             true));
-    private final BooleanProperty assumeSortedData = CSS.createBooleanProperty(this, "assumeSortedData", true);
-    private final IntegerProperty minRequiredReductionSize = registerCanvasProp(CSS.createIntegerProperty(this, "minRequiredReductionSize",
+    private final BooleanProperty assumeSortedData = css().createBooleanProperty(this, "assumeSortedData", true);
+    private final IntegerProperty minRequiredReductionSize = registerCanvasProp(css().createIntegerProperty(this, "minRequiredReductionSize",
             5));
-    private final BooleanProperty parallelImplementation = registerCanvasProp(CSS.createBooleanProperty(this, "parallelImplementation",
+    private final BooleanProperty parallelImplementation = registerCanvasProp(css().createBooleanProperty(this, "parallelImplementation",
             true));
-    private final BooleanProperty pointReduction = CSS.createBooleanProperty(this, "pointReduction", true);
+    private final BooleanProperty pointReduction = css().createBooleanProperty(this, "pointReduction", true);
 
     public AbstractPointReducingRenderer() {
         super();
@@ -160,14 +161,10 @@ public abstract class AbstractPointReducingRenderer<R extends AbstractPointReduc
     }
 
     @Override
-    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
-        return getClassCssMetaData();
+    protected CssPropertyFactory<AbstractRenderer<?>> css() {
+        return CSS;
     }
 
-    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
-        return CSS.getCssMetaData();
-    }
-
-    private static final CssPropertyFactory<AbstractRenderer<?>> CSS = new CssPropertyFactory<>(AbstractRenderer.getClassCssMetaData());
+    private static final CssPropertyFactory<AbstractRenderer<?>> CSS = new CssPropertyFactory<>(AbstractPointReducingRenderer.getClassCssMetaData());
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRenderer.java
@@ -33,7 +33,7 @@ import java.util.function.IntSupplier;
  */
 public abstract class AbstractRenderer<R extends Renderer> extends Parent implements Renderer {
 
-    protected final StyleableBooleanProperty showInLegend = CSS.createBooleanProperty(this, "showInLegend", true, this::invalidateCanvas);
+    protected final StyleableBooleanProperty showInLegend = css().createBooleanProperty(this, "showInLegend", true);
     private final ObservableList<DataSet> datasets = FXCollections.observableArrayList();
     private final ObservableList<Axis> axesList = FXCollections.observableList(new NoDuplicatesList<>());
     private final ObjectProperty<Chart> chart = new SimpleObjectProperty<>();
@@ -184,13 +184,13 @@ public abstract class AbstractRenderer<R extends Renderer> extends Parent implem
         }
     }
 
-    @Override
-    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
-        return getClassCssMetaData();
+    protected CssPropertyFactory<AbstractRenderer<?>> css() {
+        return CSS; // subclass specific CSS due to inheritance issues otherwise
     }
 
-    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
-        return CSS.getCssMetaData();
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return css().getCssMetaData();
     }
 
     private static final CssPropertyFactory<AbstractRenderer<?>> CSS = new CssPropertyFactory<>(Parent.getClassCssMetaData());

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
@@ -4,13 +4,17 @@ import java.security.InvalidParameterException;
 import java.util.Collections;
 import java.util.List;
 
+import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
 import io.fair_acc.chartfx.ui.css.LineStyle;
 import io.fair_acc.chartfx.ui.css.StyleGroup;
 import io.fair_acc.chartfx.ui.css.StyleUtil;
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
 import javafx.css.PseudoClass;
+import javafx.css.Styleable;
+import javafx.css.StyleableBooleanProperty;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -45,7 +49,7 @@ public class GridRenderer extends Parent implements Renderer {
     private final LineStyle verMajorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MAJOR_GRID_LINE, STYLE_CLASS_MAJOR_GRID_LINE_V);
     private final LineStyle horMinorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MINOR_GRID_LINE, STYLE_CLASS_MINOR_GRID_LINE_H);
     private final LineStyle verMinorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MINOR_GRID_LINE, STYLE_CLASS_MINOR_GRID_LINE_V);
-    private final LineStyle drawGridOnTopNode = styles.newLineStyle(STYLE_CLASS_GRID_ON_TOP);
+    private final StyleableBooleanProperty drawGridOnTop = CSS.createBooleanProperty(this, "drawGridOnTop", true);
 
     protected final ObservableList<Axis> axesList = FXCollections.observableList(new NoDuplicatesList<>());
 
@@ -121,7 +125,7 @@ public class GridRenderer extends Parent implements Renderer {
      * @return drawOnTop property
      */
     public final BooleanProperty drawOnTopProperty() {
-        return drawGridOnTopNode.visibleProperty();
+        return drawGridOnTop;
     }
 
     protected void drawPolarCircle(final GraphicsContext gc, final Axis yAxis, final double yRange,
@@ -340,7 +344,7 @@ public class GridRenderer extends Parent implements Renderer {
      * @return drawOnTop state
      */
     public final boolean isDrawOnTop() {
-        return drawGridOnTopNode.isVisible();
+        return drawOnTopProperty().get();
     }
 
     @Override
@@ -367,7 +371,7 @@ public class GridRenderer extends Parent implements Renderer {
      * @param state true: draw on top
      */
     public final void setDrawOnTop(boolean state) {
-        drawGridOnTopNode.setVisible(state);
+        drawOnTopProperty().set(state);
     }
 
     @Override
@@ -402,6 +406,17 @@ public class GridRenderer extends Parent implements Renderer {
     public final BooleanProperty verticalMinorGridLinesVisibleProperty() {
         return verMinorGridStyleNode.visibleProperty();
     }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return getClassCssMetaData();
+    }
+
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return CSS.getCssMetaData();
+    }
+
+    private static final CssPropertyFactory<GridRenderer> CSS = new CssPropertyFactory<>(Parent.getClassCssMetaData());
 
     protected static void applyGraphicsStyleFromLineStyle(final GraphicsContext gc, final LineStyle style) {
         style.copyStyleTo(gc);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.fair_acc.chartfx.ui.css.LineStyle;
+import io.fair_acc.chartfx.ui.css.StyleGroup;
 import io.fair_acc.chartfx.ui.css.StyleUtil;
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.FXCollections;
@@ -39,39 +40,18 @@ public class GridRenderer extends Parent implements Renderer {
     private static final String STYLE_CLASS_GRID_ON_TOP = "chart-grid-line-on-top";
     private static final PseudoClass WITH_MINOR_PSEUDO_CLASS = PseudoClass.getPseudoClass("withMinor");
 
-    private static final double[] DEFAULT_GRID_DASH_PATTERM = { 4.5, 2.5 };
-
-    private final LineStyle horMajorGridStyleNode = new LineStyle(false,
-            STYLE_CLASS_MAJOR_GRID_LINE,
-            STYLE_CLASS_MAJOR_GRID_LINE_H);
-    private final LineStyle verMajorGridStyleNode = new LineStyle(false,
-            STYLE_CLASS_MAJOR_GRID_LINE,
-            STYLE_CLASS_MAJOR_GRID_LINE_V
-    );
-    private final LineStyle horMinorGridStyleNode = new LineStyle(false,
-            STYLE_CLASS_MINOR_GRID_LINE,
-            STYLE_CLASS_MINOR_GRID_LINE_H
-    );
-    private final LineStyle verMinorGridStyleNode = new LineStyle(false,
-            STYLE_CLASS_MINOR_GRID_LINE,
-            STYLE_CLASS_MINOR_GRID_LINE_V
-    );
-    private final LineStyle drawGridOnTopNode = new LineStyle(false,
-            STYLE_CLASS_GRID_ON_TOP
-    );
+    private final StyleGroup styles = new StyleGroup(getChildren());
+    private final LineStyle horMajorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MAJOR_GRID_LINE, STYLE_CLASS_MAJOR_GRID_LINE_H);
+    private final LineStyle verMajorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MAJOR_GRID_LINE, STYLE_CLASS_MAJOR_GRID_LINE_V);
+    private final LineStyle horMinorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MINOR_GRID_LINE, STYLE_CLASS_MINOR_GRID_LINE_H);
+    private final LineStyle verMinorGridStyleNode = styles.newLineStyle(STYLE_CLASS_MINOR_GRID_LINE, STYLE_CLASS_MINOR_GRID_LINE_V);
+    private final LineStyle drawGridOnTopNode = styles.newLineStyle(STYLE_CLASS_GRID_ON_TOP);
 
     protected final ObservableList<Axis> axesList = FXCollections.observableList(new NoDuplicatesList<>());
 
     public GridRenderer() {
         super();
         StyleUtil.hiddenStyleNode(this, STYLE_CLASS_GRID_RENDERER);
-        getChildren().addAll(
-                horMajorGridStyleNode,
-                verMajorGridStyleNode,
-                horMinorGridStyleNode,
-                verMinorGridStyleNode,
-                drawGridOnTopNode
-        );
         StyleUtil.applyPseudoClass(horMajorGridStyleNode, GridRenderer.WITH_MINOR_PSEUDO_CLASS, horMinorGridStyleNode.visibleProperty());
         StyleUtil.applyPseudoClass(verMajorGridStyleNode, GridRenderer.WITH_MINOR_PSEUDO_CLASS, verMinorGridStyleNode.visibleProperty());
     }
@@ -425,9 +405,6 @@ public class GridRenderer extends Parent implements Renderer {
 
     protected static void applyGraphicsStyleFromLineStyle(final GraphicsContext gc, final LineStyle style) {
         style.copyStyleTo(gc);
-        if (style.getStrokeDashArray() == null || style.getStrokeDashArray().isEmpty()) {
-            gc.setLineDashes(DEFAULT_GRID_DASH_PATTERM);
-        }
     }
 
     private static double snap(final double value) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
@@ -119,15 +119,6 @@ public class GridRenderer extends Parent implements Renderer {
         return null;
     }
 
-    /**
-     * Indicates whether grid lines should be drawn on top or beneath graphs
-     *
-     * @return drawOnTop property
-     */
-    public final BooleanProperty drawOnTopProperty() {
-        return drawGridOnTop;
-    }
-
     protected void drawPolarCircle(final GraphicsContext gc, final Axis yAxis, final double yRange,
             final double xCentre, final double yCentre, final double maxRadius) {
         if (!horMajorGridStyleNode.isVisible() && !horMinorGridStyleNode.isVisible()) {
@@ -321,21 +312,12 @@ public class GridRenderer extends Parent implements Renderer {
     }
 
     /**
-     * Indicates whether horizontal major grid lines are visible or not.
+     * Indicates whether grid lines should be drawn on top or beneath graphs
      *
-     * @return verticalGridLinesVisible property
+     * @param state true: draw on top
      */
-    public final BooleanProperty horizontalGridLinesVisibleProperty() {
-        return horMajorGridStyleNode.visibleProperty();
-    }
-
-    /**
-     * Indicates whether horizontal minor grid lines are visible or not.
-     *
-     * @return verticalGridLinesVisible property
-     */
-    public final BooleanProperty horizontalMinorGridLinesVisibleProperty() {
-        return horMinorGridStyleNode.visibleProperty();
+    public final void setDrawOnTop(boolean state) {
+        drawOnTopProperty().set(state);
     }
 
     /**
@@ -345,6 +327,15 @@ public class GridRenderer extends Parent implements Renderer {
      */
     public final boolean isDrawOnTop() {
         return drawOnTopProperty().get();
+    }
+
+    /**
+     * Indicates whether grid lines should be drawn on top or beneath graphs
+     *
+     * @return drawOnTop property
+     */
+    public final BooleanProperty drawOnTopProperty() {
+        return drawGridOnTop;
     }
 
     @Override
@@ -365,15 +356,6 @@ public class GridRenderer extends Parent implements Renderer {
         return Collections.emptyList();
     }
 
-    /**
-     * Indicates whether grid lines should be drawn on top or beneath graphs
-     *
-     * @param state true: draw on top
-     */
-    public final void setDrawOnTop(boolean state) {
-        drawOnTopProperty().set(state);
-    }
-
     @Override
     public Renderer setShowInLegend(final boolean state) {
         return this;
@@ -387,24 +369,6 @@ public class GridRenderer extends Parent implements Renderer {
     @Override
     public BooleanProperty showInLegendProperty() {
         return null;
-    }
-
-    /**
-     * Indicates whether vertical major grid lines are visible or not.
-     *
-     * @return verticalGridLinesVisible property
-     */
-    public final BooleanProperty verticalGridLinesVisibleProperty() {
-        return verMajorGridStyleNode.visibleProperty();
-    }
-
-    /**
-     * Indicates whether vertical minor grid lines are visible or not.
-     *
-     * @return verticalGridLinesVisible property
-     */
-    public final BooleanProperty verticalMinorGridLinesVisibleProperty() {
-        return verMinorGridStyleNode.visibleProperty();
     }
 
     @Override

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
@@ -149,8 +149,8 @@ public class GridRenderer extends Parent implements Renderer {
                 gc.strokeOval(xCentre - yNorm, yCentre - yNorm, 2 * yNorm, 2 * yNorm);
 
                 gc.save();
-                gc.setFont(yAxis.getTickLabelFont());
-                gc.setStroke(yAxis.getTickLabelFill());
+                gc.setFont(yAxis.getTickLabelStyle().getFont());
+                gc.setStroke(yAxis.getTickLabelStyle().getFill()); // TODO: why stroke rather than fill?
                 gc.setLineDashes((double[]) null);
                 gc.setTextBaseline(VPos.CENTER);
                 gc.strokeText(label, xCentre + (int) yAxis.getTickLabelGap(), yCentre - yNorm);
@@ -198,8 +198,8 @@ public class GridRenderer extends Parent implements Renderer {
                 gc.strokeLine(xCentre, yCentre, x, y);
 
                 gc.save();
-                gc.setFont(yAxis.getTickLabelFont());
-                gc.setStroke(yAxis.getTickLabelFill());
+                gc.setFont(yAxis.getTickLabelStyle().getFont());
+                gc.setStroke(yAxis.getTickLabelStyle().getFill()); // TODO: why stroke rather than fill?
                 gc.setLineDashes((double[]) null);
                 gc.setTextBaseline(VPos.CENTER);
                 if (phi < 350) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/LabelledMarkerRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/LabelledMarkerRenderer.java
@@ -38,7 +38,7 @@ import io.fair_acc.dataset.utils.ProcessingProfiler;
  *
  * Points without any label data are ignored by the renderer.
  */
-public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMarkerRenderer> implements Renderer {
+public class LabelledMarkerRenderer extends AbstractRenderer<LabelledMarkerRenderer> implements Renderer {
     private static final Logger LOGGER = LoggerFactory.getLogger(LabelledMarkerRenderer.class);
     private static final String STYLE_CLASS_LABELLED_MARKER = "chart-labelled-marker";
     private static final String DEFAULT_FONT = "Helvetica";
@@ -46,7 +46,6 @@ public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMa
     private static final Color DEFAULT_GRID_LINE_COLOR = Color.GREEN;
     private static final double DEFAULT_GRID_LINE_WIDTH = 1;
     private static final double[] DEFAULT_GRID_DASH_PATTERM = { 3.0, 3.0 };
-    protected final StringProperty style = new SimpleStringProperty(this, "style", null);
     protected final BooleanProperty verticalMarker = new SimpleBooleanProperty(this, "verticalMarker", true);
     protected final BooleanProperty horizontalMarker = new SimpleBooleanProperty(this, "horizontalMarker", false);
     protected Paint strokeColorMarker = LabelledMarkerRenderer.DEFAULT_GRID_LINE_COLOR;
@@ -191,10 +190,6 @@ public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMa
         return getThis();
     }
 
-    public String getStyle() {
-        return styleProperty().get();
-    }
-
     @Override
     protected LabelledMarkerRenderer getThis() {
         return this;
@@ -315,15 +310,6 @@ public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMa
         } else {
             gc.setLineDashes(dashPattern);
         }
-    }
-
-    public LabelledMarkerRenderer setStyle(final String newStyle) {
-        styleProperty().set(newStyle);
-        return getThis();
-    }
-
-    public StringProperty styleProperty() {
-        return style;
     }
 
     public final LabelledMarkerRenderer updateCSS() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/ReducingLineRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/ReducingLineRenderer.java
@@ -29,7 +29,7 @@ import io.fair_acc.dataset.utils.ProcessingProfiler;
  * 
  * @author braeun
  */
-public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLineRenderer> implements Renderer {
+public class ReducingLineRenderer extends AbstractRenderer<ReducingLineRenderer> implements Renderer {
     private int maxPoints;
 
     public ReducingLineRenderer() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/AbstractFinancialRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/AbstractFinancialRenderer.java
@@ -12,7 +12,7 @@ import javafx.scene.paint.Paint;
 
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.renderer.Renderer;
-import io.fair_acc.chartfx.renderer.spi.AbstractDataSetManagement;
+import io.fair_acc.chartfx.renderer.spi.AbstractRenderer;
 import io.fair_acc.chartfx.renderer.spi.financial.service.OhlcvRendererEpData;
 import io.fair_acc.chartfx.renderer.spi.financial.service.PaintBarMarker;
 import io.fair_acc.dataset.DataSet;
@@ -30,7 +30,7 @@ import io.fair_acc.dataset.spi.financial.OhlcvDataSet;
  * @author afischer
  */
 @SuppressWarnings({ "PMD.ExcessiveParameterList" })
-public abstract class AbstractFinancialRenderer<R extends Renderer> extends AbstractDataSetManagement<R> implements Renderer {
+public abstract class AbstractFinancialRenderer<R extends Renderer> extends AbstractRenderer<R> implements Renderer {
     protected PaintBarMarker paintBarMarker;
 
     private final BooleanProperty computeLocalYRange = new SimpleBooleanProperty(this, "computeLocalYRange", true);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/css/FinancialColorSchemeConfig.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/css/FinancialColorSchemeConfig.java
@@ -200,10 +200,10 @@ public class FinancialColorSchemeConfig implements FinancialColorSchemeAware {
             chart.getGridRenderer().getHorizontalMajorGrid().setStroke(Color.DARKGREY);
             chart.getGridRenderer().getVerticalMajorGrid().setStroke(Color.DARKGREY);
             if (chart.getXAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getXAxis()).setTickLabelFill(Color.BLACK);
+                ((AbstractAxisParameter) chart.getXAxis()).getTickLabelStyle().setFill(Color.BLACK);
             }
             if (chart.getYAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getYAxis()).setTickLabelFill(Color.BLACK);
+                ((AbstractAxisParameter) chart.getYAxis()).getTickLabelStyle().setFill(Color.BLACK);
             }
             break;
 
@@ -216,10 +216,10 @@ public class FinancialColorSchemeConfig implements FinancialColorSchemeAware {
             chart.getGridRenderer().getHorizontalMajorGrid().setVisible(false);
             chart.getTitleLabel().setTextFill(Color.WHITE);
             if (chart.getXAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getXAxis()).setTickLabelFill(Color.WHITESMOKE);
+                ((AbstractAxisParameter) chart.getXAxis()).getTickLabelStyle().setFill(Color.WHITESMOKE);
             }
             if (chart.getYAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getYAxis()).setTickLabelFill(Color.WHITESMOKE);
+                ((AbstractAxisParameter) chart.getYAxis()).getTickLabelStyle().setFill(Color.WHITESMOKE);
             }
             break;
 
@@ -233,10 +233,10 @@ public class FinancialColorSchemeConfig implements FinancialColorSchemeAware {
             chart.getGridRenderer().getHorizontalMajorGrid().setStroke(Color.rgb(106, 106, 106));
             chart.getTitleLabel().setTextFill(Color.WHITE);
             if (chart.getXAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getXAxis()).setTickLabelFill(Color.rgb(194, 194, 194));
+                ((AbstractAxisParameter) chart.getXAxis()).getTickLabelStyle().setFill(Color.rgb(194, 194, 194));
             }
             if (chart.getYAxis() instanceof AbstractAxisParameter) {
-                ((AbstractAxisParameter) chart.getYAxis()).setTickLabelFill(Color.rgb(194, 194, 194));
+                ((AbstractAxisParameter) chart.getYAxis()).getTickLabelStyle().setFill(Color.rgb(194, 194, 194));
             }
             break;
         }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/css/FinancialColorSchemeConfig.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/financial/css/FinancialColorSchemeConfig.java
@@ -214,7 +214,7 @@ public class FinancialColorSchemeConfig implements FinancialColorSchemeAware {
             chart.getGridRenderer().getVerticalMajorGrid().setVisible(false);
             chart.getGridRenderer().getHorizontalMajorGrid().setVisible(false);
             chart.getGridRenderer().getHorizontalMajorGrid().setVisible(false);
-            chart.setTitlePaint(Color.WHITE);
+            chart.getTitleLabel().setTextFill(Color.WHITE);
             if (chart.getXAxis() instanceof AbstractAxisParameter) {
                 ((AbstractAxisParameter) chart.getXAxis()).setTickLabelFill(Color.WHITESMOKE);
             }
@@ -231,7 +231,7 @@ public class FinancialColorSchemeConfig implements FinancialColorSchemeAware {
             chart.getGridRenderer().getHorizontalMajorGrid().setVisible(true);
             chart.getGridRenderer().getHorizontalMinorGrid().setVisible(false);
             chart.getGridRenderer().getHorizontalMajorGrid().setStroke(Color.rgb(106, 106, 106));
-            chart.setTitlePaint(Color.WHITE);
+            chart.getTitleLabel().setTextFill(Color.WHITE);
             if (chart.getXAxis() instanceof AbstractAxisParameter) {
                 ((AbstractAxisParameter) chart.getXAxis()).setTickLabelFill(Color.rgb(194, 194, 194));
             }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/CssPropertyFactory.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/CssPropertyFactory.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.*;
 
+import io.fair_acc.chartfx.ui.geometry.Side;
+import io.fair_acc.chartfx.ui.layout.ChartPane;
+import io.fair_acc.dataset.utils.AssertUtils;
 import javafx.beans.property.Property;
 import javafx.css.*;
 import javafx.scene.Node;
@@ -284,6 +287,31 @@ public class CssPropertyFactory<S extends Styleable> {
      */
     public final StyleableStringProperty createStringProperty(S styleableBean, String propertyName, String initialValue, Runnable... invalidateActions) {
         return createStringProperty(styleableBean, propertyName, initialValue, true, null, invalidateActions);
+    }
+
+    /**
+     * Creates a non-null styleable side property that automatically updates the node's side in the chart. The
+     * field must be named "side".
+     *
+     * @param styleableBean the {@code this} reference of the returned property. This is also the property bean.
+     * @param initialValue the initial value of the property. CSS may reset the property to this value.
+     * @param invalidateActions zero, one or two {@code Runnable}s (vararg) first one will be executed before and second one after invalidation
+     * @return a StyleableProperty created with initial value
+     */
+    public final StyleableObjectProperty<Side> createSideProperty(S styleableBean, Side initialValue, Runnable... invalidateActions) {
+        var converter = StyleConverter.getEnumConverter(Side.class);
+        BinaryOperator<Side> filter = (old, side) -> {
+            AssertUtils.notNull("Side must not be null", side);
+            var target = styleableBean.getStyleableNode();
+            if(target == null && styleableBean instanceof Node) {
+                target = (Node) styleableBean;
+            }
+            AssertUtils.notNull("Bean does not specify a styleable node", target);
+            ChartPane.setSide(target, side);
+            return side;
+        };
+        filter.apply(null, initialValue);
+        return createObjectProperty(styleableBean, "side", initialValue, false, converter, filter, invalidateActions);
     }
 
     /**

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/LineStyle.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/LineStyle.java
@@ -3,27 +3,21 @@ package io.fair_acc.chartfx.ui.css;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.ReadOnlyLongProperty;
 import javafx.beans.property.SimpleLongProperty;
-import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.shape.Line;
 
 /**
- * An invisible node that lets users change styles
- * via CSS. The actual drawing is done in a canvas to
- * reduce the number of nodes on the SceneGraph. Each change
- * increments a counter, so that it is easy to invalidate outdated
- * renderings.
- *
  * @author ennerf
  */
-public class LineStyle extends Line implements StyleUtil.ChangeCounter {
+public class LineStyle extends Line implements StyleUtil.StyleNode {
 
     public LineStyle(String... styles) {
         StyleUtil.styleNode(this, styles);
-        StyleUtil.registerShapeListener(this, StyleUtil.incrementOnChange(changeCounter));
+        StyleUtil.forEachStyleProp(this, StyleUtil.incrementOnChange(changeCounter));
     }
 
-    public void copyStyleTo(GraphicsContext gc) {
-        StyleUtil.copyShapeStyle(this, gc);
+    @Override
+    public String toString() {
+        return StyleUtil.toStyleString(this);
     }
 
     public ReadOnlyLongProperty changeCounterProperty() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/LineStyle.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/LineStyle.java
@@ -3,12 +3,8 @@ package io.fair_acc.chartfx.ui.css;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.ReadOnlyLongProperty;
 import javafx.beans.property.SimpleLongProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.scene.Node;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.shape.Line;
-import javafx.scene.shape.Path;
-import javafx.scene.shape.Shape;
 
 /**
  * An invisible node that lets users change styles
@@ -19,19 +15,10 @@ import javafx.scene.shape.Shape;
  *
  * @author ennerf
  */
-public class LineStyle extends Line {
+public class LineStyle extends Line implements StyleUtil.ChangeCounter {
 
     public LineStyle(String... styles) {
-       this(true, styles);
-    }
-
-    public LineStyle(boolean hide, String... styles) {
-        StyleUtil.addStyles(this, styles);
-        setManaged(false);
-        // It looks like a manual set will overwrite any CSS styling
-        if (hide) {
-            setVisible(false);
-        }
+        StyleUtil.styleNode(this, styles);
         StyleUtil.registerShapeListener(this, StyleUtil.incrementOnChange(changeCounter));
     }
 
@@ -39,14 +26,10 @@ public class LineStyle extends Line {
         StyleUtil.copyShapeStyle(this, gc);
     }
 
-    public long getChangeCounter() {
-        return changeCounter.get();
-    }
-
     public ReadOnlyLongProperty changeCounterProperty() {
         return changeCounter;
     }
 
-    LongProperty changeCounter = new SimpleLongProperty(0);
+    private final LongProperty changeCounter = new SimpleLongProperty(0);
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleGroup.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleGroup.java
@@ -32,7 +32,7 @@ public class StyleGroup extends Group {
         StyleUtil.hiddenStyleNode(this);
         setAutoSizeChildren(false);
         relocate(0, 0);
-        children.add(0, this);
+        children.add(this);
     }
 
     public LineStyle newLineStyle(String... styles) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleGroup.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleGroup.java
@@ -1,0 +1,51 @@
+package io.fair_acc.chartfx.ui.css;
+
+import io.fair_acc.chartfx.utils.PropUtil;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.ReadOnlyLongProperty;
+import javafx.beans.property.SimpleLongProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+
+import javax.swing.event.ChangeListener;
+
+/**
+ * A hidden group that holds styles. This hides style nodes even
+ * if the visibility property is set to true.
+ *
+ * @author ennerf
+ */
+public class StyleGroup extends Group {
+
+    public StyleGroup(Pane pane, String... paneStyles) {
+        this(pane, pane.getChildren(), paneStyles);
+    }
+
+    public StyleGroup(Node parent, ObservableList<Node> children, String... parentStyles) {
+        this(children);
+        StyleUtil.addStyles(parent, parentStyles);
+    }
+
+    public StyleGroup(ObservableList<Node> children) {
+        StyleUtil.hiddenStyleNode(this);
+        setAutoSizeChildren(false);
+        relocate(0, 0);
+        children.add(0, this);
+    }
+
+    public LineStyle newLineStyle(String... styles) {
+        return addToChildren(new LineStyle(styles));
+    }
+
+    public TextStyle newTextStyle(String... styles) {
+        return addToChildren(new TextStyle(styles));
+    }
+
+    private <T extends Node> T addToChildren(T style) {
+        getChildren().add(style);
+        return style;
+    }
+
+}

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleUtil.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleUtil.java
@@ -2,19 +2,21 @@ package io.fair_acc.chartfx.ui.css;
 
 import io.fair_acc.chartfx.utils.FXUtils;
 import io.fair_acc.chartfx.utils.PropUtil;
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.ReadOnlyLongProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableBooleanValue;
+import javafx.beans.value.ObservableValue;
 import javafx.css.PseudoClass;
+import javafx.css.StyleableProperty;
 import javafx.scene.Node;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Text;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Utility class for styleable nodes
@@ -26,11 +28,30 @@ public class StyleUtil {
     private StyleUtil() {
     }
 
-    public interface ChangeCounter {
+    /**
+     * A node that lets users change styles via CSS. The
+     * actual drawing is done in a canvas to reduce the
+     * number of nodes on the SceneGraph. Each change
+     * increments a counter, so that it is easy to
+     * invalidate outdated renderings.
+     */
+    public interface StyleNode {
+
+        /**
+         * Copies all style parameters except for rotate
+         * @param gc target context
+         */
+        default void copyStyleTo(GraphicsContext gc) {
+            copyStyle((Node)this, gc);
+        }
+
         default long getChangeCounter() {
             return changeCounterProperty().get();
         }
 
+        /**
+         * @return a counter with the total number of style changes
+         */
         ReadOnlyLongProperty changeCounterProperty();
     }
 
@@ -68,66 +89,101 @@ public class StyleUtil {
         }, condition);
     }
 
-    static void copyNodeStyle(Node style, GraphicsContext gc) {
+    public static void forEachStyleProp(Node node, Consumer<ObservableValue<?>> action) {
         // https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#node
+        action.accept(node.visibleProperty());
+        action.accept(node.rotateProperty());
+        action.accept(node.opacityProperty());
+
+        // https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#shape
+        if (node instanceof Shape) {
+            Shape shape = (Shape) node;
+            action.accept(shape.fillProperty());
+            action.accept(shape.strokeProperty());
+            action.accept(Bindings.size(shape.getStrokeDashArray()));
+            action.accept(shape.strokeDashOffsetProperty());
+            action.accept(shape.strokeLineCapProperty());
+            action.accept(shape.strokeLineJoinProperty());
+            action.accept(shape.strokeMiterLimitProperty());
+            action.accept(shape.strokeWidthProperty());
+
+            // https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#text
+            if (node instanceof Text) {
+                Text text = (Text) node;
+                action.accept(text.fontProperty());
+                action.accept(text.fontSmoothingTypeProperty());
+                action.accept(text.textAlignmentProperty());
+                action.accept(text.textOriginProperty());
+            }
+        }
+    }
+
+    public static void copyStyle(Node style, GraphicsContext gc) {
         // rotate, translate, etc. would mess up the coordinate frame
         gc.setGlobalAlpha(style.getOpacity());
+
+        if (style instanceof Shape) {
+            Shape shape = (Shape) style;
+            gc.setFill(shape.getFill());
+            // style.isSmooth(); // no equivalent
+            gc.setStroke(shape.getStroke());
+            // style.getStrokeType(); // no equivalent
+            gc.setLineDashes(toLineDashArray(shape.getStrokeDashArray()));
+            gc.setLineDashOffset(shape.getStrokeDashOffset());
+            gc.setLineCap(shape.getStrokeLineCap());
+            gc.setLineJoin(shape.getStrokeLineJoin());
+            gc.setMiterLimit(shape.getStrokeMiterLimit());
+            gc.setLineWidth(shape.getStrokeWidth());
+
+            if (style instanceof Text) {
+                Text text = (Text) style;
+                gc.setFont(text.getFont());
+                gc.setFontSmoothingType(text.getFontSmoothingType());
+                // style.isStrikethrough(); // no equivalent
+                gc.setTextAlign(text.getTextAlignment());
+                gc.setTextBaseline(text.getTextOrigin());
+                // style.isUnderline(); // no equivalent
+            }
+        }
     }
 
-    static void registerNodeListener(Node style, ChangeListener<Object> listener) {
-        style.opacityProperty().addListener(listener);
-        style.rotateProperty().addListener(listener);
-        style.visibleProperty().addListener(listener);
+    public static String toStyleString(Node style) {
+        StringBuilder builder = new StringBuilder();
+        for (String styleClass : style.getStyleClass()) {
+            builder.append(".").append(styleClass).append(", ");
+        }
+        removeEndIf(builder, ", ");
+        builder.append(" {");
+        forEachStyleProp(style, obs -> {
+            if (!(obs instanceof StyleableProperty<?>)) {
+                return;
+            }
+            var prop = (StyleableProperty<?>) obs;
+            builder.append("\n  ").append(prop.getCssMetaData().getProperty())
+                    .append(": ").append(prop.getValue()).append(";");
+        });
+        builder.append("\n}");
+        return builder.toString();
     }
 
-    static void copyShapeStyle(Shape style, GraphicsContext gc) {
-        // https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#shape
-        gc.setFill(style.getFill());
-        // style.isSmooth(); // no equivalent
-        gc.setStroke(style.getStroke());
-        // style.getStrokeType(); // no equivalent
-        gc.setLineDashes(toLineDashArray(style.getStrokeDashArray()));
-        gc.setLineDashOffset(style.getStrokeDashOffset());
-        gc.setLineCap(style.getStrokeLineCap());
-        gc.setLineJoin(style.getStrokeLineJoin());
-        gc.setMiterLimit(style.getStrokeMiterLimit());
-        gc.setLineWidth(style.getStrokeWidth());
-        copyNodeStyle(style, gc);
+    private static boolean removeEndIf(StringBuilder builder, String end) {
+        if (builder.length() < end.length()) {
+            return false;
+        }
+        for (int i = 0; i < end.length(); i++) {
+            char a = end.charAt(end.length() - 1 - i);
+            char b = builder.charAt(builder.length() - 1 - i);
+            if (a != b) {
+                return false;
+            }
+        }
+        builder.setLength(builder.length() - end.length());
+        return true;
     }
 
-    static void registerShapeListener(Shape style, ChangeListener<Object> listener) {
-        style.fillProperty().addListener(listener);
-        style.strokeProperty().addListener(listener);
-        Bindings.size(style.getStrokeDashArray()).addListener(listener);
-        style.strokeDashOffsetProperty().addListener(listener);
-        style.strokeLineCapProperty().addListener(listener);
-        style.strokeLineJoinProperty().addListener(listener);
-        style.strokeMiterLimitProperty().addListener(listener);
-        style.strokeWidthProperty().addListener(listener);
-        registerNodeListener(style, listener);
-    }
-
-    static void copyTextStyle(Text style, GraphicsContext gc) {
-        // https://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html#text
-        gc.setFont(style.getFont());
-        gc.setFontSmoothingType(style.getFontSmoothingType());
-        // style.isStrikethrough(); // no equivalent
-        gc.setTextAlign(style.getTextAlignment());
-        gc.setTextBaseline(style.getTextOrigin());
-        // style.isUnderline(); // no equivalent
-        copyShapeStyle(style, gc);
-    }
-
-    static void registerTextListener(Text style, ChangeListener<Object> listener) {
-        style.fontProperty().addListener(listener);
-        style.fontSmoothingTypeProperty().addListener(listener);
-        style.textAlignmentProperty().addListener(listener);
-        style.textOriginProperty().addListener(listener);
-        registerShapeListener(style, listener);
-    }
-
-    static ChangeListener<Object> incrementOnChange(LongProperty counter) {
-        return (obs, old, value) -> counter.set(counter.get() + 1);
+    static Consumer<ObservableValue<?>> incrementOnChange(LongProperty counter) {
+        ChangeListener<Object> listener = (obs, old, value) -> counter.set(counter.get() + 1);
+        return prop -> prop.addListener(listener);
     }
 
     private static double[] toLineDashArray(List<Double> numbers) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/TextStyle.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/TextStyle.java
@@ -3,32 +3,21 @@ package io.fair_acc.chartfx.ui.css;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.ReadOnlyLongProperty;
 import javafx.beans.property.SimpleLongProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.text.Text;
 
 /**
- * An invisible node that lets users change styles
- * via CSS. The actual drawing is done in a canvas to
- * reduce the number of nodes on the SceneGraph. Each change
- * increments a counter, so that it is easy to invalidate outdated
- * renderings.
- *
  * @author ennerf
  */
-public class TextStyle extends Text implements StyleUtil.ChangeCounter {
+public class TextStyle extends Text implements StyleUtil.StyleNode {
 
     public TextStyle(String... styles) {
-        StyleUtil.hiddenStyleNode(this, styles);
-        StyleUtil.registerTextListener(this, StyleUtil.incrementOnChange(changeCounter));
+        StyleUtil.styleNode(this, styles);
+        StyleUtil.forEachStyleProp(this, StyleUtil.incrementOnChange(changeCounter));
     }
 
-    /**
-     * Copies all style parameters except for rotate
-     * @param gc target context
-     */
-    public void copyStyleTo(GraphicsContext gc) {
-        StyleUtil.copyTextStyle(this, gc);
+    @Override
+    public String toString() {
+        return StyleUtil.toStyleString(this);
     }
 
     public ReadOnlyLongProperty changeCounterProperty() {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/TextStyle.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/TextStyle.java
@@ -16,7 +16,7 @@ import javafx.scene.text.Text;
  *
  * @author ennerf
  */
-public class TextStyle extends Text {
+public class TextStyle extends Text implements StyleUtil.ChangeCounter {
 
     public TextStyle(String... styles) {
         StyleUtil.hiddenStyleNode(this, styles);
@@ -31,14 +31,10 @@ public class TextStyle extends Text {
         StyleUtil.copyTextStyle(this, gc);
     }
 
-    public long getChangeCounter() {
-        return changeCounter.get();
-    }
-
     public ReadOnlyLongProperty changeCounterProperty() {
         return changeCounter;
     }
 
-    LongProperty changeCounter = new SimpleLongProperty(0);
+    private final LongProperty changeCounter = new SimpleLongProperty(0);
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/geometry/Side.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/geometry/Side.java
@@ -1,5 +1,8 @@
 package io.fair_acc.chartfx.ui.geometry;
 
+import javafx.css.PseudoClass;
+import javafx.scene.Node;
+
 /**
  * Re-implementation of JavaFX's {@code javafx.geometry.Side} implementation to also include centre axes.
  * 
@@ -57,4 +60,27 @@ public enum Side {
     public boolean isCenter() {
         return this == CENTER_VER || this == CENTER_HOR;
     }
+
+    public void applyPseudoClasses(Node node) {
+        node.pseudoClassStateChanged(CSS_TOP, this == TOP);
+        node.pseudoClassStateChanged(CSS_BOTTOM, this == BOTTOM);
+        node.pseudoClassStateChanged(CSS_LEFT, this == LEFT);
+        node.pseudoClassStateChanged(CSS_RIGHT, this == RIGHT);
+        node.pseudoClassStateChanged(CSS_CENTER_HOR, this == CENTER_HOR);
+        node.pseudoClassStateChanged(CSS_CENTER_VER, this == CENTER_VER);
+        node.pseudoClassStateChanged(CSS_HORIZONTAL, isHorizontal());
+        node.pseudoClassStateChanged(CSS_VERTICAL, isVertical());
+        node.pseudoClassStateChanged(CSS_CENTER, isCenter());
+    }
+
+    private static final PseudoClass CSS_TOP = PseudoClass.getPseudoClass("top");
+    private static final PseudoClass CSS_BOTTOM = PseudoClass.getPseudoClass("bottom");
+    private static final PseudoClass CSS_LEFT = PseudoClass.getPseudoClass("left");
+    private static final PseudoClass CSS_RIGHT = PseudoClass.getPseudoClass("right");
+    private static final PseudoClass CSS_CENTER_HOR = PseudoClass.getPseudoClass("center-hor");
+    private static final PseudoClass CSS_CENTER_VER = PseudoClass.getPseudoClass("center-ver");
+    private static final PseudoClass CSS_HORIZONTAL = PseudoClass.getPseudoClass("horizontal");
+    private static final PseudoClass CSS_VERTICAL = PseudoClass.getPseudoClass("vertical");
+    private static final PseudoClass CSS_CENTER = PseudoClass.getPseudoClass("center");
+
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/ChartPane.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/ChartPane.java
@@ -5,6 +5,8 @@ import io.fair_acc.chartfx.ui.geometry.Corner;
 import io.fair_acc.chartfx.ui.geometry.Side;
 import io.fair_acc.chartfx.utils.FXUtils;
 import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
+import io.fair_acc.dataset.utils.AssertUtils;
+import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
 
@@ -46,6 +48,8 @@ public class ChartPane extends Pane {
     }
 
     public static void setSide(Node node, Side value) {
+        AssertUtils.notNull("Side must not be null", value);
+        value.applyPseudoClasses(node);
         FXUtils.setConstraint(node, CHART_ELEMENT, value);
     }
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/TitleLabel.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/TitleLabel.java
@@ -1,0 +1,84 @@
+package io.fair_acc.chartfx.ui.layout;
+
+import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
+import io.fair_acc.chartfx.ui.css.StyleUtil;
+import io.fair_acc.chartfx.ui.geometry.Side;
+import io.fair_acc.chartfx.utils.PropUtil;
+import io.fair_acc.chartfx.utils.RotatedBounds;
+import javafx.beans.binding.Bindings;
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+
+import java.util.List;
+
+/**
+ * A label that has a styleable side and accounts
+ * for rotation in the size computations.
+ *
+ * @author ennerf
+ */
+public class TitleLabel extends Label {
+
+    private static final CssPropertyFactory<TitleLabel> CSS = new CssPropertyFactory<>(Label.getClassCssMetaData());
+
+    public TitleLabel() {
+        managedProperty().bind(visibleProperty().and(textProperty().isNotEmpty()));
+        PropUtil.runOnChange(this::applyCss, sideProperty(), rotateProperty());
+    }
+
+    /**
+     * The side of the chart where the title is displayed default Side.TOP
+     */
+    private final StyleableObjectProperty<Side> side = CSS.createSideProperty(this, Side.TOP);
+
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return CSS.getCssMetaData();
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getControlCssMetaData() {
+        return TitleLabel.getClassCssMetaData();
+    }
+
+    @Override
+    protected double computePrefWidth(double length) {
+        return getRotate() == 0 ? super.computePrefWidth(length) :
+                bounds.setSize(super.computePrefWidth(length), super.computePrefHeight(length))
+                        .rotateCenter(getRotate())
+                        .getWidth();
+    }
+
+    @Override
+    protected double computePrefHeight(double length) {
+        return getRotate() == 0 ? super.computePrefHeight(length) :
+                bounds.setSize(super.computePrefWidth(length), super.computePrefHeight(length))
+                        .rotateCenter(getRotate())
+                        .getHeight();
+    }
+
+    @Override
+    public void resizeRelocate(double x, double y, double width, double height) {
+        // We need to set the bounds rotated so that the label gets computed
+        // correctly without messing up text cutoff and word wrap etc.
+        bounds.setBounds(x, y, width, height).rotateCenter(getRotate());
+        super.resizeRelocate(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+    }
+
+    public Side getSide() {
+        return side.get();
+    }
+
+    public StyleableObjectProperty<Side> sideProperty() {
+        return side;
+    }
+
+    public void setSide(Side side) {
+        this.side.set(side);
+    }
+
+    private final RotatedBounds bounds = new RotatedBounds();
+
+}

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/TitleLabel.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/layout/TitleLabel.java
@@ -1,16 +1,13 @@
 package io.fair_acc.chartfx.ui.layout;
 
 import io.fair_acc.chartfx.ui.css.CssPropertyFactory;
-import io.fair_acc.chartfx.ui.css.StyleUtil;
 import io.fair_acc.chartfx.ui.geometry.Side;
 import io.fair_acc.chartfx.utils.PropUtil;
-import io.fair_acc.chartfx.utils.RotatedBounds;
-import javafx.beans.binding.Bindings;
+import io.fair_acc.chartfx.utils.RotatedRegion;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.css.StyleableObjectProperty;
 import javafx.scene.control.Label;
-import javafx.scene.layout.Region;
 
 import java.util.List;
 
@@ -44,27 +41,18 @@ public class TitleLabel extends Label {
     }
 
     @Override
-    protected double computePrefWidth(double length) {
-        return getRotate() == 0 ? super.computePrefWidth(length) :
-                bounds.setSize(super.computePrefWidth(length), super.computePrefHeight(length))
-                        .rotateCenter(getRotate())
-                        .getWidth();
+    protected double computePrefWidth(double height) {
+        return rotated.computePrefWidth(height);
     }
 
     @Override
-    protected double computePrefHeight(double length) {
-        return getRotate() == 0 ? super.computePrefHeight(length) :
-                bounds.setSize(super.computePrefWidth(length), super.computePrefHeight(length))
-                        .rotateCenter(getRotate())
-                        .getHeight();
+    protected double computePrefHeight(double width) {
+        return rotated.computePrefHeight(width);
     }
 
     @Override
     public void resizeRelocate(double x, double y, double width, double height) {
-        // We need to set the bounds rotated so that the label gets computed
-        // correctly without messing up text cutoff and word wrap etc.
-        bounds.setBounds(x, y, width, height).rotateCenter(getRotate());
-        super.resizeRelocate(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+        rotated.resizeRelocate(x, y, width, height);
     }
 
     public Side getSide() {
@@ -79,6 +67,9 @@ public class TitleLabel extends Label {
         this.side.set(side);
     }
 
-    private final RotatedBounds bounds = new RotatedBounds();
+    private final RotatedRegion rotated = new RotatedRegion(this,
+            super::computePrefWidth,
+            super::computePrefHeight,
+            super::resizeRelocate);
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/FXUtils.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/FXUtils.java
@@ -9,6 +9,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.fair_acc.chartfx.Chart;
 import io.fair_acc.dataset.events.StateListener;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -16,6 +17,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 
 import javafx.stage.Window;
@@ -322,6 +324,21 @@ public final class FXUtils {
         });
 
         return showing;
+    }
+
+    /**
+     * @param node child
+     * @return the containing parent chart if there is one
+     */
+    public static Optional<Chart> tryGetChartParent(Node node) {
+        Parent parent = node.getParent();
+        while (parent != null) {
+            if (parent instanceof Chart) {
+                return Optional.of((Chart) parent);
+            }
+            parent = parent.getParent();
+        }
+        return Optional.empty();
     }
 
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/PropUtil.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/PropUtil.java
@@ -62,6 +62,11 @@ public class PropUtil {
         return prop;
     }
 
+    public static void initAndRunOnChange(Runnable action, ObservableValue<?>... conditions) {
+        action.run();
+        runOnChange(action, conditions);
+    }
+
     /**
      * subscribes to property changes without requiring value boxing
      */

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedBounds.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedBounds.java
@@ -1,0 +1,80 @@
+package io.fair_acc.chartfx.utils;
+
+/**
+ * Utility class for rotating bounds
+ *
+ * @author ennerf
+ */
+public class RotatedBounds {
+
+    public RotatedBounds setSize(double width, double height) {
+        this.width = width;
+        this.height = height;
+        return this;
+    }
+
+    public RotatedBounds setBounds(double x, double y, double width, double height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        return this;
+    }
+
+    /**
+     * Applies a 2D rotation around the center point.
+     * See <a href="https://en.wikipedia.org/wiki/Rotation_matrix">Rotation Matrix</a>
+     *
+     * @param rotate angle in degrees
+     */
+    public RotatedBounds rotateCenter(double rotate) {
+        // adapted from https://stackoverflow.com/a/71878932/3574093
+        if (rotate != 0) {
+            var rot = rotate * DEG_TO_RAD;
+            var cos = Math.abs(Math.cos(rot));
+            var sin = Math.abs(Math.sin(rot));
+
+            var rotWidth = width * cos + height * sin;
+            var rotHeight = width * sin + height * cos;
+
+            var rotX = x - (rotWidth - width) / 2;
+            var rotY = y - (rotHeight - height) / 2;
+
+            setBounds(rotX, rotY, rotWidth, rotHeight);
+        }
+        return this;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public double getWidth() {
+        return width;
+    }
+
+    public double getHeight() {
+        return height;
+    }
+
+    @Override
+    public String toString() {
+        return "RotatedBounds{" +
+                "x=" + x +
+                ", y=" + y +
+                ", width=" + width +
+                ", height=" + height +
+                '}';
+    }
+
+    private double x = 0;
+    private double y = 0;
+    private double width = 0;
+    private double height = 0;
+    private static final double DEG_TO_RAD = Math.PI / 180.0;
+
+}

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedBounds.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedBounds.java
@@ -1,7 +1,7 @@
 package io.fair_acc.chartfx.utils;
 
 /**
- * Utility class for rotating bounds
+ * Utility class for rotating bounding boxes.
  *
  * @author ennerf
  */
@@ -22,7 +22,7 @@ public class RotatedBounds {
     }
 
     /**
-     * Applies a 2D rotation around the center point.
+     * Applies a 2D rotation around the center point of the current bounding box.
      * See <a href="https://en.wikipedia.org/wiki/Rotation_matrix">Rotation Matrix</a>
      *
      * @param rotate angle in degrees
@@ -34,9 +34,11 @@ public class RotatedBounds {
             var cos = Math.abs(Math.cos(rot));
             var sin = Math.abs(Math.sin(rot));
 
+            // 2D rotation matrix applied to width/height
             var rotWidth = width * cos + height * sin;
             var rotHeight = width * sin + height * cos;
 
+            // Translate the origin to the new center position
             var rotX = x - (rotWidth - width) / 2;
             var rotY = y - (rotHeight - height) / 2;
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedRegion.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedRegion.java
@@ -1,0 +1,62 @@
+package io.fair_acc.chartfx.utils;
+
+import javafx.scene.Node;
+
+import java.util.function.DoubleUnaryOperator;
+
+/**
+ * Utility class for working with rotating regions/controls that are
+ * inside layout containers that do not properly account for rotations.
+ *
+ * @author ennerf
+ */
+public class RotatedRegion {
+
+    @FunctionalInterface
+    public interface ResizeRelocateMethod {
+        void apply(double x, double y, double width, double height);
+    }
+
+    public RotatedRegion(Node node, DoubleUnaryOperator computePrefWidth, DoubleUnaryOperator computePrefHeight, ResizeRelocateMethod resizeRelocate) {
+        this.node = node;
+        this.computePrefWidth = computePrefWidth;
+        this.computePrefHeight = computePrefHeight;
+        this.resizeRelocate = resizeRelocate;
+    }
+
+    public double computePrefWidth(double length) {
+        return getRotate() == 0 ? computePrefWidth.applyAsDouble(length) :
+                bounds.setSize(computePrefWidth.applyAsDouble(length), computePrefHeight.applyAsDouble(length))
+                        .rotateCenter(getRotate())
+                        .getWidth();
+    }
+
+    public double computePrefHeight(double length) {
+        return getRotate() == 0 ? computePrefHeight.applyAsDouble(length) :
+                bounds.setSize(computePrefWidth.applyAsDouble(length), computePrefHeight.applyAsDouble(length))
+                        .rotateCenter(getRotate())
+                        .getHeight();
+    }
+
+    public void resizeRelocate(double x, double y, double width, double height) {
+        if (getRotate() == 0) {
+            resizeRelocate.apply(x, y, width, height);
+        } else {
+            // The bounds need to be set rotated so that the underlying container
+            // computes a layout with appropriate word wrap, cutoff etc.
+            bounds.setBounds(x, y, width, height).rotateCenter(getRotate());
+            resizeRelocate.apply(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+        }
+    }
+
+    private double getRotate() {
+        return node.getRotate();
+    }
+
+    private final Node node;
+    private final DoubleUnaryOperator computePrefWidth;
+    private final DoubleUnaryOperator computePrefHeight;
+    private final ResizeRelocateMethod resizeRelocate;
+    private final RotatedBounds bounds = new RotatedBounds();
+
+}

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedRegion.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/RotatedRegion.java
@@ -7,6 +7,9 @@ import java.util.function.DoubleUnaryOperator;
 /**
  * Utility class for working with rotating regions/controls that are
  * inside layout containers that do not properly account for rotations.
+ * <p>
+ * Note: it currently works with our custom layout panes, but not
+ * with some built-in ones that do not call resizeRelocate.
  *
  * @author ennerf
  */

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart-icons.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart-icons.scss
@@ -1,55 +1,61 @@
 @font-face {
-  font-family: "fair-chart-icons";
-  src: url("fonts/fair-chart-icons.eot?yr8ymj");
-  src: url("fonts/fair-chart-icons.eot?yr8ymj#iefix") format("embedded-opentype"), url("fonts/fair-chart-icons.ttf?yr8ymj") format("truetype"), url("fonts/fair-chart-icons.woff?yr8ymj") format("woff"), url("fonts/fair-chart-icons.svg?yr8ymj#fair-chart-icons") format("svg");
+  font-family: 'fair-chart-icons';
+  src: url('fonts/fair-chart-icons.eot?yr8ymj');
+  src:
+    url('fonts/fair-chart-icons.eot?yr8ymj#iefix') format('embedded-opentype'),
+    url('fonts/fair-chart-icons.ttf?yr8ymj') format('truetype'),
+    url('fonts/fair-chart-icons.woff?yr8ymj') format('woff'),
+    url('fonts/fair-chart-icons.svg?yr8ymj#fair-chart-icons') format('svg');
   font-weight: normal;
   font-style: normal;
   font-display: block;
 }
-[class^=icon-],
+
+[class^="icon-"],
 [class*=" icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: "fair-chart-icons" !important;
+  font-family: 'fair-chart-icons' !important;
   speak: never;
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
   text-transform: none;
   line-height: 1;
+
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .icon-info_icon .path1::before {
-  content: "I";
+  content: "\49";
   color: rgb(0, 0, 205);
 }
 
 .icon-info_icon .path2::before {
-  content: "J";
+  content: "\4a";
   margin-left: -1em;
   color: rgb(255, 255, 255);
 }
 
 .icon-warn_icon .path1::before {
-  content: "W";
+  content: "\57";
   color: rgb(255, 215, 0);
 }
 
 .icon-warn_icon .path2::before {
-  content: "X";
+  content: "\58";
   margin-left: -1.1376953125em;
   color: rgb(0, 0, 0);
 }
 
 .icon-error_icon .path1::before {
-  content: "E";
+  content: "\45";
   color: rgb(237, 28, 36);
 }
 
 .icon-error_icon .path2::before {
-  content: "F";
+  content: "\46";
   margin-left: -1em;
   color: rgb(255, 255, 255);
 }

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -7,15 +7,6 @@
   -fx-text-alignment: center;
 }
 
-.axis-label {
-  -fx-axis-label-alignment: center;
-  -fx-stroke: transparent;
-}
-
-.axis-tick-label {
-  -fx-stroke: transparent;
-}
-
 .chart, .chart-content, .chart-plot-area {
   /*
    Set some reasonable default sizes so users
@@ -139,6 +130,31 @@
 .range-indicator-rect {
   -fx-stroke: transparent;
   -fx-fill: rgba(65, 110, 244, 0.4078431373);
+}
+
+.axis {
+  overlapPolicy: SKIP_ALT;
+  axisCenterPosition: 0.5;
+}
+.axis .axis-label, .axis .axis-tick-label {
+  visibility: visible;
+  -fx-font-family: "System";
+  -fx-font-smoothing-type: gray;
+  -fx-stroke: transparent;
+  -fx-fill: black;
+  -fx-text-alignment: CENTER;
+  -fx-rotate: 0;
+}
+.axis .axis-label {
+  -fx-font-size: 12px;
+}
+.axis .axis-tick-label {
+  -fx-font-size: 10px;
+}
+.axis .axis-tick-mark, .axis .axis-minor-tick-mark {
+  visibility: visible;
+  -fx-stroke: #c3c3c3;
+  -fx-stroke-width: 1;
 }
 
 .grid-renderer .chart-major-grid-lines {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -132,6 +132,13 @@
   -fx-fill: rgba(65, 110, 244, 0.4078431373);
 }
 
+.chart {
+  -fx-title-side: TOP;
+  -fx-tool-bar-side: TOP;
+  -fx-legend-side: BOTTOM;
+  -fx-legend-visibility: true;
+}
+
 .axis {
   -fx-border-width: 0px;
   -fx-auto-ranging: true;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -131,10 +131,23 @@
 }
 
 .chart {
-  -fx-title-side: TOP;
   -fx-tool-bar-side: TOP;
   -fx-legend-side: BOTTOM;
   -fx-legend-visibility: true;
+}
+.chart .chart-content {
+  -fx-padding: 5 0 0 0px;
+}
+.chart .chart-title {
+  visibility: visible;
+  -fx-side: top;
+  -fx-rotate: 0;
+}
+.chart .chart-title:left {
+  -fx-rotate: -90;
+}
+.chart .chart-title:right {
+  -fx-rotate: 90;
 }
 
 .axis {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -132,8 +132,6 @@
 
 .chart {
   -fx-tool-bar-side: TOP;
-  -fx-legend-side: BOTTOM;
-  -fx-legend-visibility: true;
 }
 .chart .chart-content {
   -fx-padding: 5 0 0 0px;
@@ -148,6 +146,20 @@
 }
 .chart .chart-title:right {
   -fx-rotate: 90;
+}
+.chart .chart-legend {
+  visibility: visible;
+  -fx-orientation: horizontal;
+  -fx-side: bottom;
+  -fx-vgap: 5px;
+  -fx-hgap: 5px;
+  -fx-alignment: center;
+  -fx-symbol-width: 20;
+  -fx-symbol-height: 20;
+}
+.chart .chart-legend .chart-legend-item {
+  -fx-alignment: center-left;
+  -fx-content-display: left;
 }
 
 .axis {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -7,22 +7,6 @@
   -fx-text-alignment: center;
 }
 
-.chart, .chart-content, .chart-plot-area {
-  /*
-   Set some reasonable default sizes so users
-   can override them via CSS and JavaFX panes
-   won't flicker (usually +/- 1px) or act odd.
-   */
-  -fx-min-height: 100px;
-  -fx-min-width: 100px;
-  -fx-pref-height: 500px;
-  -fx-pref-width: 500px;
-  -fx-max-width: 4096px;
-  -fx-max-height: 4096px;
-  /* no padding by default */
-  -fx-padding: 0px;
-}
-
 .chart-crosshair-path {
   -fx-stroke-width: 1;
 }
@@ -69,7 +53,6 @@
 
 .chart-series-line {
   -fx-stroke-width: 1px;
-  -fx-effect: NULL;
 }
 
 .value-indicator-label {
@@ -132,6 +115,21 @@
   -fx-fill: rgba(65, 110, 244, 0.4078431373);
 }
 
+/*
+ Set some reasonable default sizes so users
+ can override them via CSS and JavaFX panes
+ won't flicker (usually +/- 1px) or act odd.
+ */
+.chart, .chart-content, .chart-plot-area {
+  -fx-padding: 0px;
+  -fx-min-width: 100px;
+  -fx-min-height: 100px;
+  -fx-pref-width: 600px;
+  -fx-pref-height: 450px;
+  -fx-max-height: 4096px;
+  -fx-max-width: 4096px;
+}
+
 .chart {
   -fx-title-side: TOP;
   -fx-tool-bar-side: TOP;
@@ -175,7 +173,6 @@
   -fx-font-size: 12px;
 }
 .axis .axis-tick-label {
-  -fx-text-alignment: NULL;
   -fx-font-size: 10px;
 }
 .axis .axis-tick-mark, .axis .axis-minor-tick-mark {
@@ -213,16 +210,6 @@
 }
 .grid-renderer .chart-minor-horizontal-grid-lines .chart-minor-grid-lines {
   /* use this to override h-specific settings */
-}
-
-.chart-alternative-column-fill {
-  -fx-fill: NULL;
-  -fx-stroke: NULL;
-}
-
-.chart-alternative-row-fill {
-  -fx-fill: NULL;
-  -fx-stroke: NULL;
 }
 
 .chart-vertical-zero-line,

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -194,6 +194,9 @@
   -fx-stroke-width: 1;
 }
 
+.grid-renderer {
+  -fx-draw-grid-on-top: true;
+}
 .grid-renderer .chart-major-grid-lines {
   -fx-stroke: derive(-fx-background, -10%);
   -fx-stroke-dash-array: 4.5, 2.5;
@@ -208,9 +211,6 @@
   -fx-stroke-dash-array: 4.5, 2.5;
   -fx-stroke-width: 0.5;
   visibility: hidden;
-}
-.grid-renderer .chart-grid-line-on-top {
-  visibility: visible; /* 'visible' for front, 'hidden' for back */
 }
 .grid-renderer .chart-major-vertical-lines .chart-major-grid-lines {
   /* use this to override v-specific settings */

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -161,6 +161,13 @@
   -fx-alignment: center-left;
   -fx-content-display: left;
 }
+.chart .renderer {
+  -fx-show-in-legend: true;
+  -fx-assume-sorted-data: true;
+  -fx-min-required-reduction-size: 5;
+  -fx-parallel-implementation: true;
+  -fx-point-reduction: true;
+}
 
 .axis {
   -fx-border-width: 0px;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -133,8 +133,21 @@
 }
 
 .axis {
-  overlapPolicy: SKIP_ALT;
-  axisCenterPosition: 0.5;
+  -fx-border-width: 0px;
+  -fx-auto-ranging: true;
+  -fx-auto-grow-ranging: false;
+  -fx-auto-range-rounding: false;
+  -fx-axis-center-position: 0.5;
+  -fx-overlap-policy: SKIP_ALT;
+  -fx-axis-padding: 15px;
+  -fx-tick-label-spacing: 3px;
+  -fx-max-major-tick-label-count: 20;
+  -fx-minor-tick-count: 10;
+  -fx-tick-mark-gap: 0px;
+  -fx-tick-length: 8px;
+  -fx-minor-tick-length: 5px;
+  -fx-tick-label-gap: 3px;
+  -fx-axis-label-gap: 3px;
 }
 .axis .axis-label, .axis .axis-tick-label {
   visibility: visible;
@@ -142,13 +155,20 @@
   -fx-font-smoothing-type: gray;
   -fx-stroke: transparent;
   -fx-fill: black;
-  -fx-text-alignment: CENTER;
   -fx-rotate: 0;
 }
+.axis:left .axis-label, .axis:right .axis-label, .axis:center-ver .axis-label {
+  -fx-rotate: -90;
+}
+.axis:center-ver .axis-label, .axis:center-hor .axis-label {
+  -fx-text-alignment: RIGHT;
+}
 .axis .axis-label {
+  -fx-text-alignment: CENTER;
   -fx-font-size: 12px;
 }
 .axis .axis-tick-label {
+  -fx-text-alignment: NULL;
   -fx-font-size: 10px;
 }
 .axis .axis-tick-mark, .axis .axis-minor-tick-mark {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -133,9 +133,6 @@
 .chart {
   -fx-tool-bar-side: TOP;
 }
-.chart .chart-content {
-  -fx-padding: 5 0 0 0px;
-}
 .chart .chart-title {
   visibility: visible;
   -fx-side: top;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -162,15 +162,15 @@
   -fx-fill: black;
   -fx-rotate: 0;
 }
-.axis:left .axis-label, .axis:right .axis-label, .axis:center-ver .axis-label {
-  -fx-rotate: -90;
-}
-.axis:center-ver .axis-label, .axis:center-hor .axis-label {
-  -fx-text-alignment: RIGHT;
-}
 .axis .axis-label {
   -fx-text-alignment: CENTER;
   -fx-font-size: 12px;
+}
+.axis:center .axis-label {
+  -fx-text-alignment: RIGHT;
+}
+.axis:vertical .axis-label {
+  -fx-rotate: -90;
 }
 .axis .axis-tick-label {
   -fx-font-size: 10px;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -165,6 +165,22 @@
   -fx-parallel-implementation: true;
   -fx-point-reduction: true;
 }
+.chart .error-dataset-renderer {
+  -fx-poly-line-style: normal;
+  -fx-error-style: errorcombo;
+  -fx-dash-size: 3;
+  -fx-allow-nans: false;
+  -fx-draw-bubbles: false;
+  -fx-draw-marker: true;
+  -fx-marker-size: 1.5;
+  -fx-draw-bars: false;
+  -fx-shift-bar: true;
+  -fx-shift-bar-offset: 3;
+  -fx-dynamic-bar-width: true;
+  -fx-bar-width-percentage: 70;
+  -fx-bar-width: 5;
+  -fx-intensity-fading: 0.65;
+}
 
 .axis {
   -fx-border-width: 0px;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -141,40 +141,34 @@
   -fx-fill: rgba(65, 110, 244, 0.4078431373);
 }
 
-.chart-major-grid-lines {
+.grid-renderer .chart-major-grid-lines {
   -fx-stroke: derive(-fx-background, -10%);
   -fx-stroke-dash-array: 4.5, 2.5;
   -fx-stroke-width: 0.5;
   visibility: visible;
 }
-
-.chart-major-grid-lines:withMinor {
+.grid-renderer .chart-major-grid-lines:withMinor {
   -fx-stroke: derive(-fx-background, -20%);
 }
-
-.chart-minor-grid-lines {
+.grid-renderer .chart-minor-grid-lines {
   -fx-stroke: derive(-fx-background, -5%);
+  -fx-stroke-dash-array: 4.5, 2.5;
   -fx-stroke-width: 0.5;
   visibility: hidden;
 }
-
-.chart-grid-line-on-top {
+.grid-renderer .chart-grid-line-on-top {
   visibility: visible; /* 'visible' for front, 'hidden' for back */
 }
-
-.chart-major-vertical-lines .chart-major-grid-lines {
+.grid-renderer .chart-major-vertical-lines .chart-major-grid-lines {
   /* use this to override v-specific settings */
 }
-
-.chart-major-horizontal-grid-lines .chart-major-grid-lines {
+.grid-renderer .chart-major-horizontal-grid-lines .chart-major-grid-lines {
   /* use this to override h-specific settings */
 }
-
-.chart-minor-vertical-grid-lines .chart-minor-grid-lines {
+.grid-renderer .chart-minor-vertical-grid-lines .chart-minor-grid-lines {
   /* use this to override v-specific settings */
 }
-
-.chart-minor-horizontal-grid-lines .chart-minor-grid-lines {
+.grid-renderer .chart-minor-horizontal-grid-lines .chart-minor-grid-lines {
   /* use this to override h-specific settings */
 }
 

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.css
@@ -167,6 +167,9 @@
   -fx-auto-ranging: true;
   -fx-auto-grow-ranging: false;
   -fx-auto-range-rounding: false;
+  -fx-auto-range-padding: 0;
+  -fx-auto-unit-scaling: false;
+  -fx-invert-axis: false;
   -fx-axis-center-position: 0.5;
   -fx-overlap-policy: SKIP_ALT;
   -fx-axis-padding: 15px;
@@ -198,9 +201,10 @@
   -fx-rotate: -90;
 }
 .axis .axis-tick-label {
+  -fx-fill: black;
   -fx-font-size: 10px;
 }
-.axis .axis-tick-mark, .axis .axis-minor-tick-mark {
+.axis .axis-major-tick-mark, .axis .axis-minor-tick-mark {
   visibility: visible;
   -fx-stroke: #c3c3c3;
   -fx-stroke-width: 1;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -122,6 +122,12 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 .chart {
   .chart-measurement-pane {
     .chart-title-pane, .chart-legend-pane {
+      .chart-title {
+      }
+      .chart-legend {
+        .chart-legend-item {
+        }
+      }
       .chart-content {
         .axis {
           .axis-tick-mark {
@@ -172,8 +178,6 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 .chart {
   // TODO: they don't seem to work and maybe we should create panes with a side property? deprecate these?
   -fx-tool-bar-side: TOP;
-  -fx-legend-side: BOTTOM;
-  -fx-legend-visibility: true;
 
   .chart-content {
     // leave some top-axis overdraw-padding if there is no title
@@ -191,6 +195,23 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 
     &:right {
       -fx-rotate: 90;
+    }
+
+  }
+
+  .chart-legend {
+    visibility: visible;
+    -fx-orientation: horizontal;
+    -fx-side: bottom;
+    -fx-vgap: 5px;
+    -fx-hgap: 5px;
+    -fx-alignment: center;
+    -fx-symbol-width: 20;
+    -fx-symbol-height: 20;
+
+    .chart-legend-item {
+      -fx-alignment: center-left;
+      -fx-content-display: left;
     }
 
   }

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -157,6 +157,16 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
   }
 }
 
+// XY Chart styles
+.chart {
+  // TODO: they don't seem to work and maybe we should create panes with a side property? deprecate these?
+  -fx-title-side: TOP;
+  -fx-tool-bar-side: TOP;
+  -fx-legend-side: BOTTOM;
+  -fx-legend-visibility: true;
+}
+
+// Axis styles
 .axis {
 
   -fx-border-width: 0px;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -211,21 +211,17 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
     -fx-rotate: 0;
   }
 
-  &:left, &:right, &:center-ver {
-    .axis-label {
-      -fx-rotate: -90;
-    }
-  }
-
-  &:center-ver, &:center-hor {
-    .axis-label {
-      -fx-text-alignment: RIGHT;
-    }
-  }
-
   .axis-label {
     -fx-text-alignment: CENTER;
     -fx-font-size: 12px;
+  }
+
+  &:center .axis-label {
+    -fx-text-alignment: RIGHT;
+  }
+
+  &:vertical .axis-label {
+    -fx-rotate: -90;
   }
 
   .axis-tick-label {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -171,10 +171,30 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 // XY Chart styles
 .chart {
   // TODO: they don't seem to work and maybe we should create panes with a side property? deprecate these?
-  -fx-title-side: TOP;
   -fx-tool-bar-side: TOP;
   -fx-legend-side: BOTTOM;
   -fx-legend-visibility: true;
+
+  .chart-content {
+    // leave some top-axis overdraw-padding if there is no title
+    -fx-padding: 5 0 0 0px
+  }
+
+  .chart-title {
+    visibility: visible;
+    -fx-side: top;
+    -fx-rotate: 0;
+
+    &:left {
+      -fx-rotate: -90;
+    }
+
+    &:right {
+      -fx-rotate: 90;
+    }
+
+  }
+
 }
 
 // Axis styles

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -1,4 +1,4 @@
-$null: NULL; // lowercase gets removed from Sass, but uppercase seems to also be interpreted as null
+$null: NULL; // lowercase gets removed from Sass. Maybe replace after generation?
 
 .chart-datapoint-tooltip-label {
   -fx-background-color: rgb(153, 204, 204);
@@ -7,15 +7,6 @@ $null: NULL; // lowercase gets removed from Sass, but uppercase seems to also be
   -fx-font-size: 12;
   -fx-font-weight: bold;
   -fx-text-alignment: center;
-}
-
-.axis-label {
-  -fx-axis-label-alignment: center;
-  -fx-stroke: transparent;
-}
-
-.axis-tick-label {
-  -fx-stroke: transparent;
 }
 
 .chart, .chart-content, .chart-plot-area {
@@ -142,6 +133,38 @@ $null: NULL; // lowercase gets removed from Sass, but uppercase seems to also be
 .range-indicator-rect {
   -fx-stroke: transparent;
   -fx-fill: #416ef468;
+}
+
+.axis {
+
+  // TODO: were any of these custom properties tested to work?
+  overlapPolicy: SKIP_ALT;
+  axisCenterPosition: 0.5;
+
+  .axis-label, .axis-tick-label {
+    visibility: visible;
+    -fx-font-family: 'System';
+    -fx-font-smoothing-type: gray; // gray | lcd
+    -fx-stroke: transparent;
+    -fx-fill: black;
+    -fx-text-alignment: CENTER;
+    -fx-rotate: 0;
+  }
+
+  .axis-label {
+    -fx-font-size: 12px;
+  }
+
+  .axis-tick-label {
+    -fx-font-size: 10px;
+  }
+
+  .axis-tick-mark, .axis-minor-tick-mark {
+    visibility: visible;
+    -fx-stroke: #c3c3c3ff;
+    -fx-stroke-width: 1.0;
+  }
+
 }
 
 .grid-renderer {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -1,4 +1,4 @@
-$null: NULL; // null gets removed from Sass. Maybe replace after generation?
+$null: null; // null gets removed from Sass. Maybe create a placeholder and replace after generation?
 
 .chart-datapoint-tooltip-label {
   -fx-background-color: rgb(153, 204, 204);
@@ -7,23 +7,6 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
   -fx-font-size: 12;
   -fx-font-weight: bold;
   -fx-text-alignment: center;
-}
-
-.chart, .chart-content, .chart-plot-area {
-  /*
-   Set some reasonable default sizes so users
-   can override them via CSS and JavaFX panes
-   won't flicker (usually +/- 1px) or act odd.
-   */
-  -fx-min-height: 100px;
-  -fx-min-width: 100px;
-  -fx-pref-height: 500px;
-  -fx-pref-width: 500px;
-  -fx-max-width: 4096px;
-  -fx-max-height: 4096px;
-
-  /* no padding by default */
-  -fx-padding: 0px;
 }
 
 .chart-crosshair-path {
@@ -135,12 +118,20 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
   -fx-fill: #416ef468;
 }
 
-// Full Pane hierarchy
+// Full Chart hierarchy for reference
 .chart {
   .chart-measurement-pane {
     .chart-title-pane, .chart-legend-pane {
       .chart-content {
         .axis {
+          .axis-tick-mark {
+          }
+          .axis-minor-tick-mark {
+          }
+          .axis-label {
+          }
+          .axis-tick-label {
+          }
         }
         .chart-plot-background {
         }
@@ -153,8 +144,28 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
       }
     }
   }
+
   .grid-renderer {
+    .chart-major-grid-lines {
+    }
+    .chart-minor-grid-lines {
+    }
   }
+}
+
+/*
+ Set some reasonable default sizes so users
+ can override them via CSS and JavaFX panes
+ won't flicker (usually +/- 1px) or act odd.
+ */
+.chart, .chart-content, .chart-plot-area {
+  -fx-padding: 0px;
+  -fx-min-width: 100px;
+  -fx-min-height: 100px;
+  -fx-pref-width: 600px;
+  -fx-pref-height: 450px;
+  -fx-max-height: 4096px;
+  -fx-max-width: 4096px;
 }
 
 // XY Chart styles
@@ -174,7 +185,7 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
   // Determining data range
   -fx-auto-ranging: true; // always updates to the range of the data
   -fx-auto-grow-ranging: false; // range updates, but won't shrink
-  -fx-auto-range-rounding: false; // rounds range up
+  -fx-auto-range-rounding: false; // auto range w/ rounding
 
   // Tick spacing (along the width on horizontal axes)
   -fx-axis-center-position: 0.5; // only for centered axes: relative position of the center line
@@ -221,7 +232,6 @@ $null: NULL; // null gets removed from Sass. Maybe replace after generation?
     -fx-text-alignment: $null;
     -fx-font-size: 10px;
   }
-
 
   .axis-tick-mark, .axis-minor-tick-mark {
     visibility: visible;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -1,4 +1,4 @@
-$null: NULL; // lowercase gets removed from Sass. Maybe replace after generation?
+$null: NULL; // null gets removed from Sass. Maybe replace after generation?
 
 .chart-datapoint-tooltip-label {
   -fx-background-color: rgb(153, 204, 204);
@@ -135,11 +135,51 @@ $null: NULL; // lowercase gets removed from Sass. Maybe replace after generation
   -fx-fill: #416ef468;
 }
 
+// Full Pane hierarchy
+.chart {
+  .chart-measurement-pane {
+    .chart-title-pane, .chart-legend-pane {
+      .chart-content {
+        .axis {
+        }
+        .chart-plot-background {
+        }
+        .chart-plot-content {
+          .chart-plot-area {
+          }
+        }
+        .chart-plot-foreground {
+        }
+      }
+    }
+  }
+  .grid-renderer {
+  }
+}
+
 .axis {
 
-  // TODO: were any of these custom properties tested to work?
-  overlapPolicy: SKIP_ALT;
-  axisCenterPosition: 0.5;
+  -fx-border-width: 0px;
+
+  // Determining data range
+  -fx-auto-ranging: true; // always updates to the range of the data
+  -fx-auto-grow-ranging: false; // range updates, but won't shrink
+  -fx-auto-range-rounding: false; // rounds range up
+
+  // Tick spacing (along the width on horizontal axes)
+  -fx-axis-center-position: 0.5; // only for centered axes: relative position of the center line
+  -fx-overlap-policy: SKIP_ALT; // DO_NOTHING, SKIP_ALT, NARROW_FONT, SHIFT_ALT, FORCED_SHIFT_ALT
+  -fx-axis-padding: 15px; // overdraw area to the sides of the axis
+  -fx-tick-label-spacing: 3px; // min spacing between two tick labels
+  -fx-max-major-tick-label-count: 20;
+  -fx-minor-tick-count: 10;
+
+  // Axis size (maps to height on horizontal axes)
+  -fx-tick-mark-gap: 0px; // gap between canvas and axis line
+  -fx-tick-length: 8px; // length of tick mark lines
+  -fx-minor-tick-length: 5px; // length of minor tick mark lines
+  -fx-tick-label-gap: 3px; // gap between tick marks and labels
+  -fx-axis-label-gap: 3px; // gap between tick labels and axis label
 
   .axis-label, .axis-tick-label {
     visibility: visible;
@@ -147,17 +187,31 @@ $null: NULL; // lowercase gets removed from Sass. Maybe replace after generation
     -fx-font-smoothing-type: gray; // gray | lcd
     -fx-stroke: transparent;
     -fx-fill: black;
-    -fx-text-alignment: CENTER;
     -fx-rotate: 0;
   }
 
+  &:left, &:right, &:center-ver {
+    .axis-label {
+      -fx-rotate: -90;
+    }
+  }
+
+  &:center-ver, &:center-hor {
+    .axis-label {
+      -fx-text-alignment: RIGHT;
+    }
+  }
+
   .axis-label {
+    -fx-text-alignment: CENTER;
     -fx-font-size: 12px;
   }
 
   .axis-tick-label {
+    -fx-text-alignment: $null;
     -fx-font-size: 10px;
   }
+
 
   .axis-tick-mark, .axis-minor-tick-mark {
     visibility: visible;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -144,41 +144,51 @@ $null: NULL; // lowercase gets removed from Sass, but uppercase seems to also be
   -fx-fill: #416ef468;
 }
 
-.chart-major-grid-lines {
-  -fx-stroke: derive(-fx-background, -10%);
-  -fx-stroke-dash-array: 4.5, 2.5;
-  -fx-stroke-width: 0.5;
-  visibility: visible;
-}
+.grid-renderer {
 
-.chart-major-grid-lines:withMinor {
-  -fx-stroke: derive(-fx-background, -20%);
-}
+  $DEFAULT_GRID_DASH_PATTERN: 4.5, 2.5;
+  $DEFAULT_LINE_WIDTH: 0.5;
 
-.chart-minor-grid-lines {
-  -fx-stroke: derive(-fx-background, -5%);
-  -fx-stroke-width: 0.5;
-  visibility: hidden;
-}
+  .chart-major-grid-lines {
+    -fx-stroke: derive(-fx-background, -10%);
+    -fx-stroke-dash-array: $DEFAULT_GRID_DASH_PATTERN;
+    -fx-stroke-width: $DEFAULT_LINE_WIDTH;
+    visibility: visible;
 
-.chart-grid-line-on-top {
-  visibility: visible; /* 'visible' for front, 'hidden' for back */
-}
+    // less subtle if we also show the minor grid lines
+    &:withMinor {
+      -fx-stroke: derive(-fx-background, -20%);
+    }
 
-.chart-major-vertical-lines .chart-major-grid-lines {
-  /* use this to override v-specific settings */
-}
+  }
 
-.chart-major-horizontal-grid-lines .chart-major-grid-lines {
-  /* use this to override h-specific settings */
-}
+  .chart-minor-grid-lines {
+    -fx-stroke: derive(-fx-background, -5%);
+    -fx-stroke-dash-array: $DEFAULT_GRID_DASH_PATTERN;
+    -fx-stroke-width: $DEFAULT_LINE_WIDTH;
+    visibility: hidden;
+  }
 
-.chart-minor-vertical-grid-lines .chart-minor-grid-lines {
-  /* use this to override v-specific settings */
-}
+  .chart-grid-line-on-top {
+    visibility: visible; /* 'visible' for front, 'hidden' for back */
+  }
 
-.chart-minor-horizontal-grid-lines .chart-minor-grid-lines {
-  /* use this to override h-specific settings */
+  .chart-major-vertical-lines .chart-major-grid-lines {
+    /* use this to override v-specific settings */
+  }
+
+  .chart-major-horizontal-grid-lines .chart-major-grid-lines {
+    /* use this to override h-specific settings */
+  }
+
+  .chart-minor-vertical-grid-lines .chart-minor-grid-lines {
+    /* use this to override v-specific settings */
+  }
+
+  .chart-minor-horizontal-grid-lines .chart-minor-grid-lines {
+    /* use this to override h-specific settings */
+  }
+
 }
 
 .chart-alternative-column-fill {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -261,6 +261,7 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 
   $DEFAULT_GRID_DASH_PATTERN: 4.5, 2.5;
   $DEFAULT_LINE_WIDTH: 0.5;
+  -fx-draw-grid-on-top: true;
 
   .chart-major-grid-lines {
     -fx-stroke: derive(-fx-background, -10%);
@@ -280,10 +281,6 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
     -fx-stroke-dash-array: $DEFAULT_GRID_DASH_PATTERN;
     -fx-stroke-width: $DEFAULT_LINE_WIDTH;
     visibility: hidden;
-  }
-
-  .chart-grid-line-on-top {
-    visibility: visible; /* 'visible' for front, 'hidden' for back */
   }
 
   .chart-major-vertical-lines .chart-major-grid-lines {

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -1,3 +1,5 @@
+$null: NULL; // lowercase gets removed from Sass, but uppercase seems to also be interpreted as null
+
 .chart-datapoint-tooltip-label {
   -fx-background-color: rgb(153, 204, 204);
   -fx-border-color: black;
@@ -28,6 +30,7 @@
   -fx-pref-width: 500px;
   -fx-max-width: 4096px;
   -fx-max-height: 4096px;
+
   /* no padding by default */
   -fx-padding: 0px;
 }
@@ -78,7 +81,7 @@
 
 .chart-series-line {
   -fx-stroke-width: 1px;
-  -fx-effect: NULL;
+  -fx-effect: $null;
 }
 
 .value-indicator-label {
@@ -133,12 +136,12 @@
 .value-watch-indicator-marker {
   -fx-stroke-width: 0.5;
   -fx-stroke: black;
-  -fx-fill: #416ef4;
+  -fx-fill: #416ef4ff;
 }
 
 .range-indicator-rect {
   -fx-stroke: transparent;
-  -fx-fill: rgba(65, 110, 244, 0.4078431373);
+  -fx-fill: #416ef468;
 }
 
 .chart-major-grid-lines {
@@ -179,13 +182,13 @@
 }
 
 .chart-alternative-column-fill {
-  -fx-fill: NULL;
-  -fx-stroke: NULL;
+  -fx-fill: $null;
+  -fx-stroke: $null;
 }
 
 .chart-alternative-row-fill {
-  -fx-fill: NULL;
-  -fx-stroke: NULL;
+  -fx-fill: $null;
+  -fx-stroke: $null;
 }
 
 .chart-vertical-zero-line,

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -216,6 +216,17 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
 
   }
 
+  .renderer {
+    // abstract renderer
+    -fx-show-in-legend: true;
+
+    // point reducing renderers
+    -fx-assume-sorted-data: true;
+    -fx-min-required-reduction-size: 5;
+    -fx-parallel-implementation: true;
+    -fx-point-reduction: true;
+  }
+
 }
 
 // Axis styles

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -130,7 +130,7 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
       }
       .chart-content {
         .axis {
-          .axis-tick-mark {
+          .axis-major-tick-mark {
           }
           .axis-minor-tick-mark {
           }
@@ -228,6 +228,10 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
   -fx-auto-grow-ranging: false; // range updates, but won't shrink
   -fx-auto-range-rounding: false; // auto range w/ rounding
 
+  -fx-auto-range-padding: 0;
+  -fx-auto-unit-scaling: false;
+  -fx-invert-axis: false;
+
   // Tick spacing (along the width on horizontal axes)
   -fx-axis-center-position: 0.5; // only for centered axes: relative position of the center line
   -fx-overlap-policy: SKIP_ALT; // DO_NOTHING, SKIP_ALT, NARROW_FONT, SHIFT_ALT, FORCED_SHIFT_ALT
@@ -266,11 +270,12 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
   }
 
   .axis-tick-label {
+    -fx-fill: black;
     -fx-text-alignment: $null;
     -fx-font-size: 10px;
   }
 
-  .axis-tick-mark, .axis-minor-tick-mark {
+  .axis-major-tick-mark, .axis-minor-tick-mark {
     visibility: visible;
     -fx-stroke: #c3c3c3ff;
     -fx-stroke-width: 1.0;

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -222,6 +222,25 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
     -fx-point-reduction: true;
   }
 
+  .error-dataset-renderer {
+    -fx-poly-line-style: normal; // normal, area, zero-order-holder, stair-case, histogram, histogram-filled, bezier-curve
+    -fx-error-style: errorcombo; // none, errorbars, errorsurface, errorcombo
+    -fx-dash-size: 3;
+    -fx-allow-nans: false;
+
+    -fx-draw-bubbles: false;
+    -fx-draw-marker: true;
+    -fx-marker-size: 1.5;
+
+    -fx-draw-bars: false;
+    -fx-shift-bar: true;
+    -fx-shift-bar-offset: 3;
+    -fx-dynamic-bar-width: true;
+    -fx-bar-width-percentage: 70.0;
+    -fx-bar-width: 5;
+    -fx-intensity-fading: 0.65;
+  }
+
 }
 
 // Axis styles

--- a/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
+++ b/chartfx-chart/src/main/resources/io/fair_acc/chartfx/chart.scss
@@ -179,11 +179,6 @@ $null: null; // null gets removed from Sass. Maybe create a placeholder and repl
   // TODO: they don't seem to work and maybe we should create panes with a side property? deprecate these?
   -fx-tool-bar-side: TOP;
 
-  .chart-content {
-    // leave some top-axis overdraw-padding if there is no title
-    -fx-padding: 5 0 0 0px
-  }
-
   .chart-title {
     visibility: visible;
     -fx-side: top;

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/ChartTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/ChartTest.java
@@ -29,14 +29,14 @@ public class ChartTest {
 
     @TestFx
     public void setTitlePaint() {
-        chart.setTitlePaint(Color.BLUE);
-        assertEquals(Color.BLUE, chart.getTitlePaint().getTextFill());
+        chart.getTitleLabel().setTextFill(Color.BLUE);
+        assertEquals(Color.BLUE, chart.getTitleLabel().getTextFill());
     }
 
     @TestFx
     public void setTitleSide() {
-        chart.setTitleSide(Side.RIGHT);
-        assertEquals(Side.RIGHT, chart.getTitleSide());
+        chart.getTitleLabel().setSide(Side.RIGHT);
+        assertEquals(Side.RIGHT, chart.getTitleLabel().getSide());
     }
 
     private static class TestChart extends Chart {
@@ -52,8 +52,5 @@ public class ChartTest {
         protected void redrawCanvas() {
         }
 
-        public Label getTitlePaint() {
-            return titleLabel;
-        }
     }
 }

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameterTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameterTests.java
@@ -231,11 +231,6 @@ class AbstractAxisParameterTests {
         assertEquals(0.2, axis.getAxisCenterPosition());
         axis.setAxisCenterPosition(0.5);
 
-        assertEquals(TextAlignment.CENTER, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
-        axis.setAxisLabelTextAlignment(TextAlignment.LEFT);
-        assertEquals(TextAlignment.LEFT, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
-        axis.setAxisLabelTextAlignment(TextAlignment.CENTER);
-
         axis.setAxisLabelGap(5);
         assertEquals(5, axis.getAxisLabelGap());
 
@@ -248,11 +243,11 @@ class AbstractAxisParameterTests {
         AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
         axis.set(0.0, 10.0);
 
-        axis.setTickLabelFill(Color.RED);
-        assertEquals(Color.RED, axis.getTickLabelFill());
+        axis.getTickLabelStyle().setFill(Color.RED);
+        assertEquals(Color.RED, axis.getTickLabelStyle().getFill());
 
         final Font font = Font.font("System", 10);
-        axis.setTickLabelFont(font);
+        axis.getTickLabelStyle().setFont(font);
         assertEquals(font, axis.getTickLabelFont());
 
         StringConverter<Number> myConverter = new StringConverter<>() {
@@ -275,13 +270,13 @@ class AbstractAxisParameterTests {
         axis.setTickLabelSpacing(5);
         assertEquals(5, axis.getTickLabelSpacing());
 
-        axis.setTickLabelRotation(10);
+        axis.getTickLabelStyle().setRotate(10);
         assertEquals(10, axis.getTickLabelRotation());
 
         assertTrue(axis.isTickLabelsVisible());
-        axis.setTickLabelsVisible(false);
+        axis.getTickLabelStyle().setVisible(false);
         assertFalse(axis.isTickLabelsVisible());
-        axis.setTickLabelsVisible(true);
+        axis.getTickLabelStyle().setVisible(true);
     }
 
     @Test
@@ -316,17 +311,17 @@ class AbstractAxisParameterTests {
         assertEquals(20, axis.getMinorTickLength());
 
         assertTrue(axis.isMinorTickVisible());
-        axis.setMinorTickVisible(false);
+        axis.getMinorTickStyle().setVisible(false);
         assertFalse(axis.isMinorTickVisible());
-        axis.setMinorTickVisible(true);
+        axis.getMinorTickStyle().setVisible(true);
 
         axis.setTickLength(20);
         assertEquals(20, axis.getTickLength());
 
         assertTrue(axis.isTickMarkVisible());
-        axis.setTickMarkVisible(false);
+        axis.getMajorTickStyle().setVisible(false);
         assertFalse(axis.isTickMarkVisible());
-        axis.setTickMarkVisible(true);
+        axis.getMajorTickStyle().setVisible(true);
 
         assertNotNull(axis.getTickMarks());
         assertNotNull(axis.getTickMarkValues());

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameterTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameterTests.java
@@ -173,7 +173,7 @@ class AbstractAxisParameterTests {
             assertTrue(state.isDirty(ChartBits.AxisLayout));
             state.clear(ChartBits.AxisLayout);
         }
-        axis.setSide(null);
+        assertThrows(IllegalArgumentException.class, () -> axis.setSide(null));
         assertEquals(Double.NaN, axis.getLength());
         axis.setSide(Side.LEFT);
 

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisTests.java
@@ -95,8 +95,8 @@ class AbstractAxisTests {
         assertDoesNotThrow(() -> axis.drawAxis(null, 100, 100));
         assertDoesNotThrow(() -> AbstractAxis.drawTickMarkLabel(gc, 10, 10, 1.0, new TickMark(Side.BOTTOM, 1.0, 1.0, 0.0, "label")));
         assertDoesNotThrow(() -> AbstractAxis.drawTickMarkLabel(gc, 10, 10, 0.9, new TickMark(Side.BOTTOM, 1.0, 1.0, 90.0, "label")));
-        axis.setTickMarkVisible(false);
-        axis.setMinorTickVisible(false);
+        axis.getMajorTickStyle().setVisible(false);
+        axis.getMinorTickStyle().setVisible(false);
         assertDoesNotThrow(() -> axis.drawAxis(gc, 100, 100));
     }
 
@@ -278,7 +278,7 @@ class AbstractAxisTests {
         var style = axis.getTickLabelStyle();
 
         // No rotation
-        axis.setTickLabelRotation(0);
+        axis.getTickLabelStyle().setRotate(0);
         axis.setSide(Side.TOP);
         assertEquals(TextAlignment.CENTER, style.getTextAlignment());
         assertEquals(VPos.BOTTOM, style.getTextOrigin());
@@ -296,7 +296,7 @@ class AbstractAxisTests {
         assertEquals(VPos.CENTER, style.getTextOrigin());
 
         // 90 deg
-        axis.setTickLabelRotation(90);
+        axis.getTickLabelStyle().setRotate(90);
         axis.setSide(Side.TOP);
         assertEquals(TextAlignment.LEFT, style.getTextAlignment());
         assertEquals(VPos.CENTER, style.getTextOrigin());
@@ -315,7 +315,7 @@ class AbstractAxisTests {
 
 
         // special non 'n x 90 degree' rotation cases for top/bottom
-        axis.setTickLabelRotation(45);
+        axis.getTickLabelStyle().setRotate(45);
 
         axis.setSide(Side.TOP);
         assertEquals(TextAlignment.LEFT, style.getTextAlignment());

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/AbstractAxisTests.java
@@ -160,20 +160,20 @@ class AbstractAxisTests {
         axis.setUnit(null);
         axis.setSide(Side.BOTTOM);
         assertEquals(+1.0, axis.calculateNewScale(10, -5.0, +5.0));
-        assertEquals(+25, axis.computePrefHeight(100), 2);
+        assertEquals(+30, axis.computePrefHeight(100), 2);
         assertEquals(+150.0, axis.computePrefWidth(-1));
         axis.setSide(Side.LEFT);
         assertEquals(-1.0, axis.calculateNewScale(10, -5.0, +5.0));
         assertEquals(+150, axis.computePrefHeight(-1));
-        assertEquals(+22, axis.computePrefWidth(100), 2);
+        assertEquals(+26, axis.computePrefWidth(100), 2);
 
         axis.setUnit("");
         axis.setSide(Side.BOTTOM);
-        assertEquals(+44, axis.computePrefHeight(100), 2);
+        assertEquals(+49, axis.computePrefHeight(100), 2);
         assertEquals(+150.0, axis.computePrefWidth(-1));
         axis.setSide(Side.LEFT);
         assertEquals(+150, axis.computePrefHeight(-1));
-        assertEquals(+44, axis.computePrefWidth(100), 2);
+        assertEquals(+48, axis.computePrefWidth(100), 2);
 
         assertDoesNotThrow(axis::clear);
         assertDoesNotThrow(axis::forceRedraw);

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/plugins/ScreenshotTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/plugins/ScreenshotTest.java
@@ -140,8 +140,8 @@ class ScreenshotTest {
             assertEquals("testDataSet_4.5_4.500000e-06.png", screenshotPlugin.generateScreenshotName());
             screenshotPlugin.setPattern("");
             chart.setTitle("");
-            chart.setTitleSide(Side.RIGHT);
-            chart.setTitlePaint(Color.BLUE);
+            chart.getTitleLabel().setSide(Side.RIGHT);
+            chart.getTitleLabel().setTextFill(Color.BLUE);
 
             assertEquals("testDataSet", screenshotPlugin.generateScreenshotName()); //first data set name
             chart.getDatasets().clear();

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/ErrorDataSetRendererTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/ErrorDataSetRendererTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
+import io.fair_acc.chartfx.ui.utils.TestFx;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
@@ -74,13 +75,20 @@ public class ErrorDataSetRendererTests {
     @EnumSource(LineStyle.class)
     public void testRendererNominal(final LineStyle lineStyle) throws Exception {
         for (ErrorStyle eStyle : ErrorStyle.values()) {
-            renderer.setErrorType(eStyle);
-            testRenderer(lineStyle);
+            FXUtils.runAndWait(() -> {
+                renderer.setErrorType(eStyle);
+                try {
+                    testRenderer(lineStyle);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
     }
 
     @Test
-    public void testRendererSepcialCases() throws Exception {
+    @TestFx
+    public void testRendererSpecialCases() throws Exception {
         final LineStyle lineStyle = LineStyle.NORMAL;
 
         renderer.setPointReduction(false);

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/LabelledMarkerRendererTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/LabelledMarkerRendererTests.java
@@ -74,11 +74,11 @@ public class LabelledMarkerRendererTests {
         localRenderer.enableHorizontalMarker(true);
         assertTrue(localRenderer.isHorizontalMarker());
 
-        assertNull(localRenderer.getStyle());
+        assertEquals("", localRenderer.getStyle());
         localRenderer.setStyle("arbitrary");
         assertEquals("arbitrary", localRenderer.getStyle());
         localRenderer.setStyle(null);
-        assertNull(localRenderer.getStyle());
+        assertEquals("", localRenderer.getStyle());
     }
 
     @Test

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/CandleStickRendererTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/CandleStickRendererTest.java
@@ -86,7 +86,7 @@ public class CandleStickRendererTest {
     @TestFx
     public void categoryAxisTest() {
         final CategoryAxis xAxis = new CategoryAxis("time [iso]");
-        xAxis.setTickLabelRotation(90);
+        xAxis.getTickLabelStyle().setRotate(90);
         xAxis.setOverlapPolicy(AxisLabelOverlapPolicy.SKIP_ALT);
         ohlcvDataSet.setCategoryBased(true);
 

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/FootprintRendererTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/FootprintRendererTest.java
@@ -100,7 +100,7 @@ public class FootprintRendererTest {
     @TestFx
     public void categoryAxisTest() {
         final CategoryAxis xAxis = new CategoryAxis("time [iso]");
-        xAxis.setTickLabelRotation(90);
+        xAxis.getTickLabelStyle().setRotate(90);
         xAxis.setOverlapPolicy(AxisLabelOverlapPolicy.SKIP_ALT);
         ohlcvDataSet.setCategoryBased(true);
 

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/HighLowRendererTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/HighLowRendererTest.java
@@ -86,7 +86,7 @@ class HighLowRendererTest {
     @TestFx
     void categoryAxisTest() {
         final CategoryAxis xAxis = new CategoryAxis("time [iso]");
-        xAxis.setTickLabelRotation(90);
+        xAxis.getTickLabelStyle().setRotate(90);
         xAxis.setOverlapPolicy(AxisLabelOverlapPolicy.SKIP_ALT);
         ohlcvDataSet.setCategoryBased(true);
 

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/PositionFinancialRendererPaintAfterEPTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/renderer/spi/financial/PositionFinancialRendererPaintAfterEPTest.java
@@ -97,7 +97,7 @@ class PositionFinancialRendererPaintAfterEPTest {
     @TestFx
     public void categoryAxisTest() {
         final CategoryAxis xAxis = new CategoryAxis("time [iso]");
-        xAxis.setTickLabelRotation(90);
+        xAxis.getTickLabelStyle().setRotate(90);
         xAxis.setOverlapPolicy(AxisLabelOverlapPolicy.SKIP_ALT);
         ohlcvDataSet.setCategoryBased(true);
         chart.getAxes().add(0, xAxis);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ChartAnatomySample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ChartAnatomySample.java
@@ -48,13 +48,13 @@ public class ChartAnatomySample extends Application {
         xAxis2.setSide(Side.TOP);
         xAxis3.setSide(Side.CENTER_HOR);
         xAxis3.setMinorTickCount(2);
-        xAxis3.setAxisLabelTextAlignment(TextAlignment.RIGHT);
+        xAxis3.getAxisLabel().setTextAlignment(TextAlignment.RIGHT);
         yAxis1.setSide(Side.LEFT);
         yAxis2.setSide(Side.RIGHT);
         yAxis3.setSide(Side.RIGHT);
         yAxis4.setSide(Side.CENTER_VER);
         yAxis4.setMinorTickCount(2);
-        yAxis4.setAxisLabelTextAlignment(TextAlignment.RIGHT);
+        yAxis4.getAxisLabel().setTextAlignment(TextAlignment.RIGHT);
 
         final Chart chart = new Chart() {
             @Override

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ChartIndicatorSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ChartIndicatorSample.java
@@ -200,8 +200,8 @@ public class ChartIndicatorSample extends ChartSample {
 
         xAxis1.setAutoRangeRounding(false);
         xAxis2.setAutoRangeRounding(false);
-        xAxis1.setTickLabelRotation(45);
-        xAxis2.setTickLabelRotation(45);
+        xAxis1.getTickLabelStyle().setRotate(45);
+        xAxis2.getTickLabelStyle().setRotate(45);
         xAxis1.invertAxis(false);
         xAxis2.invertAxis(false);
         xAxis1.setTimeAxis(true);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ErrorDataSetRendererStylingSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ErrorDataSetRendererStylingSample.java
@@ -195,7 +195,7 @@ public class ErrorDataSetRendererStylingSample extends Application {
 
         final CheckBox gridVisibleX = new CheckBox("");
         gridVisibleX.setSelected(true);
-        chart.horizontalGridLinesVisibleProperty().bindBidirectional(gridVisibleX.selectedProperty());
+        chart.getGridRenderer().getHorizontalMajorGrid().visibleProperty().bindBidirectional(gridVisibleX.selectedProperty());
         pane.addToParameterPane("Show X-Grid: ", gridVisibleX);
 
         final CheckBox gridVisibleXMinor = new CheckBox("");
@@ -205,7 +205,7 @@ public class ErrorDataSetRendererStylingSample extends Application {
 
         final CheckBox gridVisibleY = new CheckBox("");
         gridVisibleY.setSelected(true);
-        chart.verticalGridLinesVisibleProperty().bindBidirectional(gridVisibleY.selectedProperty());
+        chart.getGridRenderer().getVerticalMajorGrid().visibleProperty().bindBidirectional(gridVisibleY.selectedProperty());
         pane.addToParameterPane("Show Y-Grid: ", gridVisibleY);
 
         final CheckBox gridVisibleYMinor = new CheckBox("");

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/HistogramSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/HistogramSample.java
@@ -74,7 +74,7 @@ public class HistogramSample extends ChartSample {
     public Node getChartPanel(final Stage primaryStage) {
         final StackPane root = new StackPane();
         final CategoryAxis xAxis1 = new CategoryAxis("months");
-        xAxis1.setTickLabelRotation(90);
+        xAxis1.getTickLabelStyle().setRotate(90);
 
         final DefaultNumericAxis xAxis2 = new DefaultNumericAxis("x-Axis");
         xAxis2.setAutoRangeRounding(false);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/OscilloscopeAxisSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/OscilloscopeAxisSample.java
@@ -263,7 +263,7 @@ public class OscilloscopeAxisSample extends ChartSample {
 
         final XYChart chart = new XYChart(xAxis, yAxis1);
         chart.setTitle(defaultAxis ? "Chart with DefaultNumericAxis" : "Chart with OscilloscopeAxis");
-        chart.legendVisibleProperty().set(false);
+        chart.setLegendVisible(false);
         chart.getYAxis().setName(rollingBufferBeamIntensity.getName());
         final ErrorDataSetRenderer beamIntensityRenderer = (ErrorDataSetRenderer) chart.getRenderers().get(0);
         ((DefaultDataReducer) beamIntensityRenderer.getRendererDataReducer()).setMinPointPixelDistance(MIN_PIXEL_DISTANCE);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RollingBufferSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RollingBufferSample.java
@@ -165,7 +165,7 @@ public class RollingBufferSample extends ChartSample {
 
         final DefaultNumericAxis xAxis1 = new DefaultNumericAxis("time");
         xAxis1.setAutoRangeRounding(false);
-        xAxis1.setTickLabelRotation(45);
+        xAxis1.getTickLabelStyle().setRotate(45);
         xAxis1.setMinorTickCount(30);
         xAxis1.invertAxis(false);
         xAxis1.setTimeAxis(true);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RollingBufferSortedTreeSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RollingBufferSortedTreeSample.java
@@ -146,7 +146,7 @@ public class RollingBufferSortedTreeSample extends ChartSample {
 
         final DefaultNumericAxis xAxis1 = new DefaultNumericAxis("time");
         xAxis1.setAutoRangeRounding(false);
-        xAxis1.setTickLabelRotation(45);
+        xAxis1.getTickLabelStyle().setRotate(45);
         xAxis1.invertAxis(false);
         xAxis1.setTimeAxis(true);
         final DefaultNumericAxis yAxis1 = new DefaultNumericAxis("beam intensity", "ppp");

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RotatedAxisLabelSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RotatedAxisLabelSample.java
@@ -45,7 +45,7 @@ public class RotatedAxisLabelSample extends ChartSample {
 
             final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis (-90°, " + policy + ")");
             yAxis1.setSide(Side.LEFT);
-            yAxis1.setTickLabelRotation(-90);
+            yAxis1.getTickLabelStyle().setRotate(-90);
             yAxis1.setOverlapPolicy(policy);
 
             chart.getAxes().addAll(xAxis1, yAxis1);
@@ -58,7 +58,7 @@ public class RotatedAxisLabelSample extends ChartSample {
 
                 final DefaultNumericAxis yAxis2 = getSynchedAxis(yAxis0, "y-axis (-90°, " + policy + ") + extra label spacing");
                 yAxis2.setSide(Side.LEFT);
-                yAxis2.setTickLabelRotation(-90);
+                yAxis2.getTickLabelStyle().setRotate(-90);
                 yAxis2.setOverlapPolicy(policy);
                 yAxis2.setTickLabelSpacing(10);
 
@@ -69,13 +69,13 @@ public class RotatedAxisLabelSample extends ChartSample {
         final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis (45°)");
         xAxis1.setSide(Side.BOTTOM);
         xAxis1.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
-        xAxis1.setTickLabelRotation(45);
+        xAxis1.getTickLabelStyle().setRotate(45);
         xAxis1.setMaxMajorTickLabelCount(40);
 
         final DefaultNumericAxis xAxis2 = getSynchedAxis(xAxis0, "x-axis (90°)");
         xAxis2.setSide(Side.BOTTOM);
         xAxis2.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
-        xAxis2.setTickLabelRotation(90);
+        xAxis2.getTickLabelStyle().setRotate(90);
         xAxis2.setMaxMajorTickLabelCount(40);
 
         chart.getAxes().addAll(xAxis1, xAxis2);
@@ -83,7 +83,7 @@ public class RotatedAxisLabelSample extends ChartSample {
         final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis (-45°)");
         yAxis1.setSide(Side.LEFT);
         yAxis1.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
-        yAxis1.setTickLabelRotation(-45);
+        yAxis1.getTickLabelStyle().setRotate(-45);
 
         chart.getAxes().addAll(yAxis1);
 
@@ -100,8 +100,7 @@ public class RotatedAxisLabelSample extends ChartSample {
         final DefaultNumericAxis axis = new DefaultNumericAxis(newAxisName);
         axis.minProperty().bind(orig.minProperty());
         axis.maxProperty().bind(orig.maxProperty());
-        axis.setTickLabelRotation(orig.getTickLabelRotation());
-
+        axis.getTickLabelStyle().setRotate(orig.getTickLabelStyle().getRotate());
         return axis;
     }
 

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/SimpleChartSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/SimpleChartSample.java
@@ -58,7 +58,7 @@ public class SimpleChartSample extends ChartSample {
 
         // TODO: fix legend layouting, for now works only for top and is not really nice
         chart.setLegendVisible(true);
-        chart.setLegendSide(Side.TOP);
+        chart.getLegend().setSide(Side.TOP);
 
         return new StackPane(chart);
     }


### PR DESCRIPTION
This PR includes some styling changes for the components that are comparatively easy to deal with. Datasets will require more work and will be in a separate PR.

* added SCSS integration
* made axes fully styleable (including the side)
* fixed CSS styling for the grid renderer
* added CSS styling for the error renderer
* removed duplicate properties
* removed many convenience methods for styling, e.g., setLabelFill(color)` -> `getLabel.setFill(color)`. This may result in a bit more effort to port, but it cleans up the API and should help encourage the use of CSS.
* added extra pseudo classes for sides (e.g. `vertical`, `horizontal`, `center`)

**Bugfixes**
* Fixes #560 grid styling
* fixed some tick-label artifacts caused by rendering labels outside the parent pane (e.g. the bottom-left x-axis tick if the y axis is on the right)

**Demos with Sass and live CSS reloading**

* [ChartFX#598: Renderer styling demo](https://youtu.be/ExJ0gswwjd0)
* [ChartFX#598: Axis styling demo](https://youtu.be/9LsBp9vCVKU)

**Notes**

- [ ] The CssPropertyFactory in some Axes (e.g. `NumericAxis`) gets initialized with the static properties from the parent class before they are valid. This is a bug in current main.
- [ ] The legend initializes and renders the symbols before the CSS info is available. The symbols should be updated in the draw phase.
