### PR TITLE
Samples: fix non-terminating samples

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/SimplePerformanceMeter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/SimplePerformanceMeter.java
@@ -76,6 +76,7 @@ public class SimplePerformanceMeter extends Region {
             @Override
             public void handle(long now) {
                 pulseCounter.getAndIncrement();
+                updateProperties();
             }
         };
 
@@ -212,8 +213,6 @@ public class SimplePerformanceMeter extends Region {
                 frameRateAvgInternal = computeAverage(frameRateInternal, frameRateAvgInternal, alpha);
                 cpuLoadProcessAvgInternal = computeAverage(cpuLoadProcessInternal, cpuLoadProcessAvgInternal, alpha);
                 cpuLoadSystemAvgInternal = computeAverage(cpuLoadSystemInternal, cpuLoadSystemAvgInternal, alpha);
-
-                FXUtils.runFX(SimplePerformanceMeter.this::updateProperties);
             }
         }, 0, updateDuration);
         scene.addPostLayoutPulseListener(pulseListener);

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/ui/ProfilerInfoBoxTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/ui/ProfilerInfoBoxTests.java
@@ -74,9 +74,8 @@ public class ProfilerInfoBoxTests {
     public void testSetterGetter() {
         assertDoesNotThrow((ThrowingSupplier<ProfilerInfoBox>) ProfilerInfoBox::new);
         assertDoesNotThrow(() -> new ProfilerInfoBox(1000));
-        assertDoesNotThrow(() -> new ProfilerInfoBox(new Scene(new Pane(), 100, 100)));
+        assertDoesNotThrow(() -> new ProfilerInfoBox());
 
-        //        final Scene scene = new Scene(new Pane(), 100,100);
         final ProfilerInfoBox infoBox = new ProfilerInfoBox(); // force fastest update
 
         for (final DebugLevel debugLevel : DebugLevel.values()) {

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/Histogram2DimSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/Histogram2DimSample.java
@@ -139,7 +139,7 @@ public class Histogram2DimSample extends ChartSample {
             @Override
             public void run() {
                 fillData();
-                FXUtils.runFX(chart::invalidate);
+                chart.invalidate();
             }
         }, Histogram2DimSample.UPDATE_DELAY, Histogram2DimSample.UPDATE_PERIOD);
         return root;

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/PaddedAutoGrowAxisSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/PaddedAutoGrowAxisSample.java
@@ -2,6 +2,7 @@ package io.fair_acc.sample.chart;
 
 import java.util.concurrent.TimeUnit;
 
+import io.fair_acc.dataset.utils.CachedDaemonThreadFactory;
 import javafx.application.Application;
 import javafx.scene.Node;
 import javafx.stage.Stage;
@@ -12,7 +13,6 @@ import io.fair_acc.chartfx.plugins.EditAxis;
 import io.fair_acc.chartfx.plugins.Zoomer;
 import io.fair_acc.chartfx.utils.FXUtils;
 import io.fair_acc.dataset.spi.CircularDoubleErrorDataSet;
-import io.fair_acc.math.Math;
 
 /**
  * Auto grow-ranging example.
@@ -37,7 +37,7 @@ public class PaddedAutoGrowAxisSample extends ChartSample {
 
         var ds = new CircularDoubleErrorDataSet("", 150);
         chart.getDatasets().addAll(ds);
-        new Thread(() -> {
+        CachedDaemonThreadFactory.getInstance().newThread(() -> {
             while (true) {
                 ds.reset();
                 try {

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/utils/MidiWaveformSynthesizer.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/utils/MidiWaveformSynthesizer.java
@@ -188,13 +188,6 @@ public class MidiWaveformSynthesizer {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public void finalize() { // NOPMD needed and on purpose
-        sequencer.close();
-        synthesizer.close();
-    }
-
     public DoubleCircularBuffer getBuffer() {
         return buffer;
     }
@@ -263,9 +256,17 @@ public class MidiWaveformSynthesizer {
     }
 
     public void stop() {
-        sequencer.stop();
-        sequencer.setTickPosition(0);
+        if (sequencer.isOpen()) {
+            sequencer.stop();
+            sequencer.setTickPosition(0);
+        }
         reset();
+    }
+
+    public void close() {
+        stop();
+        sequencer.close();
+        synthesizer.close();
     }
 
     public void update(final int samplingRate, final int nBits) {

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/utils/TestDataSetSource.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/utils/TestDataSetSource.java
@@ -67,7 +67,7 @@ public class TestDataSetSource extends AbstractDataSet<TestDataSetSource> implem
 
     protected transient Timer updateTimer;
     protected transient Timer audioTimer;
-    protected transient TimerTask traskAudioIO;
+    protected transient TimerTask taskAudioIO;
     protected transient TimerTask taskDataUpdate;
 
     public TestDataSetSource() {
@@ -216,7 +216,7 @@ public class TestDataSetSource extends AbstractDataSet<TestDataSetSource> implem
 
         if (audioTimer != null) {
             audioTimer.cancel();
-            traskAudioIO.cancel();
+            taskAudioIO.cancel();
             audioTimer = null;
         }
 
@@ -226,8 +226,8 @@ public class TestDataSetSource extends AbstractDataSet<TestDataSetSource> implem
         }
 
         audioTimer = new Timer(TestDataSetSource.class.getSimpleName() + "-Audio", true);
-        traskAudioIO = getAudioTimerTask();
-        audioTimer.schedule(traskAudioIO, 0);
+        taskAudioIO = getAudioTimerTask();
+        audioTimer.schedule(taskAudioIO, 0);
 
         updateTimer = new Timer(TestDataSetSource.class.getSimpleName() + "-Data", true);
         taskDataUpdate = getDataUpdateTask();
@@ -257,6 +257,11 @@ public class TestDataSetSource extends AbstractDataSet<TestDataSetSource> implem
         running = false;
         paused = false;
         synth.stop();
+    }
+
+    public void close() {
+        stop();
+        synth.close();
     }
 
     protected TimerTask getAudioTimerTask() {

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/SimpleOhlcvReplayDataSet.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/SimpleOhlcvReplayDataSet.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.fair_acc.dataset.events.ChartBits;
+import io.fair_acc.dataset.utils.CachedDaemonThreadFactory;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
@@ -172,7 +173,7 @@ public class SimpleOhlcvReplayDataSet extends OhlcvDataSet implements Iterable<I
     public void start() {
         paused.set(false);
         running.set(true);
-        new Thread(getDataUpdateTask()).start();
+        CachedDaemonThreadFactory.getInstance().newThread(getDataUpdateTask()).start();
     }
 
     public void step() {


### PR DESCRIPTION
There are mainly 3 reasons for the samples not to terminate:
- SimplePerformanceMeter (and the ProfilerInfoBox based on it) This class registers some javafx hooks which will cause the application to fail to terminate. For now it is removed from the samples, but should be repaired before merging this
- PaddedGrowAxis used a non deamonised Updateer thread
- The Midi based dataset for the Waterfall plot causes problems commented out for now but should be repaired before merge
- Histogram2DimSample called runFx from a javafx timer, after removing that, it terminates correctly

followup of #571, see there for further context