### PR TITLE
Fix zoom transformations to be based on display coordinates instead of data coordinates

### DIFF
--- a/chartfx-acc/pom.xml
+++ b/chartfx-acc/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>acc</artifactId>
     <name>chartfx-acc</name>
     <properties>
-        <project.moduleName>io.fair-acc.acc</project.moduleName>
+        <project.moduleName>io.fair_acc.acc</project.moduleName>
         <javalin.version>3.9.0</javalin.version>
         <jetty.version>9.4.29.v20200521</jetty.version> <!-- always update version with Javalin -->
         <micrometer.version>1.5.1</micrometer.version>

--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>chartfx</artifactId>
     <name>chartfx-chart</name>
     <properties>
-        <project.moduleName>io.fair-acc.chartfx</project.moduleName>
+        <project.moduleName>io.fair_acc.chartfx</project.moduleName>
         <sass.version>1.64.2</sass.version>
         <scss.inputDir>${project.basedir}/src/main/resources/io/fair_acc/chartfx/</scss.inputDir>
         <css.outputDir>${scss.inputDir}</css.outputDir>

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/Axis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/Axis.java
@@ -361,4 +361,11 @@ public interface Axis extends AxisDescription {
      * @return the canvas of the axis
      */
     Canvas getCanvas();
+
+    /**
+     * Hook to manually update the cached axis transforms outside of the render loop.
+     * This is needed e.g. when plugins adjust the axes and at the same time need to perform
+     * transformations with the modified ranges.
+     */
+    default void updateCachedTransforms() {};
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxis.java
@@ -250,7 +250,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         updateScaleAndUnitPrefix();
 
         // Update the cache to the new range
-        updateCachedVariables();
+        updateCachedTransforms();
 
         // Compute new tick marks and locations
         updateMajorTickMarks(range);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/AbstractAxisParameter.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Objects;
 
 import io.fair_acc.chartfx.ui.css.*;
-import io.fair_acc.chartfx.ui.layout.ChartPane;
 import io.fair_acc.chartfx.utils.PropUtil;
 import io.fair_acc.dataset.events.BitState;
 import io.fair_acc.dataset.events.ChartBits;
@@ -15,10 +14,7 @@ import javafx.collections.ObservableList;
 import javafx.css.*;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
-import javafx.scene.text.TextAlignment;
 import javafx.util.StringConverter;
 
 import io.fair_acc.chartfx.Chart;
@@ -360,7 +356,8 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     /**
      * to be overwritten by derived class that want to cache variables for efficiency reasons
      */
-    protected void updateCachedVariables() { // NOPMD by rstein function can but does not have to be overwritten
+    @Override
+    public void updateCachedTransforms() { // NOPMD by rstein function can but does not have to be overwritten
         // called once new axis parameters have been established
         cachedOffset = getSide().isHorizontal() ? 0 : getLength();
     }
@@ -816,7 +813,8 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
 
     @Override
     public boolean set(final double min, final double max) {
-        return PropUtil.set(minProp, min) | PropUtil.set(maxProp, max);
+        final boolean result = PropUtil.set(minProp, min) | PropUtil.set(maxProp, max);
+        return result;
     }
 
     @Override

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/DefaultNumericAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/DefaultNumericAxis.java
@@ -1,10 +1,5 @@
 package io.fair_acc.chartfx.axes.spi;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import io.fair_acc.chartfx.utils.PropUtil;
 import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 import javafx.beans.property.BooleanProperty;
@@ -540,8 +535,8 @@ public class DefaultNumericAxis extends AbstractAxis implements Axis {
     }
 
     @Override
-    protected void updateCachedVariables() {
-        super.updateCachedVariables();
+    public void updateCachedTransforms() {
+        super.updateCachedTransforms();
         if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return;
         }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/OscilloscopeAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/OscilloscopeAxis.java
@@ -372,8 +372,8 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
     }
 
     @Override
-    protected void updateCachedVariables() {
-        super.updateCachedVariables();
+    public void updateCachedTransforms() {
+        super.updateCachedTransforms();
         if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return;
         }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/FXUtils.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/FXUtils.java
@@ -21,6 +21,7 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 
+import javafx.scene.layout.Pane;
 import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -390,4 +391,10 @@ public final class FXUtils {
         });
     }
 
+    public static Pane createUnmanagedPane() {
+        final Pane pane = new Pane();
+        pane.setManaged(false);
+        pane.relocate(0, 0);
+        return pane;
+    }
 }

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/DefaultNumericAxisTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/DefaultNumericAxisTests.java
@@ -80,7 +80,7 @@ public class DefaultNumericAxisTests {
         assertTrue(axis.isLogAxis());
         assertEquals(LogAxisType.LOG10_SCALE, axis.getLogAxisType());
         axis.setMin(0.1);
-        axis.updateCachedVariables();
+        axis.updateCachedTransforms();
         axis.layoutChildren();
         assertEquals(axis.getZeroPosition(), axis.getDisplayPosition(axis.getMin()));
         assertEquals(10, axis.getLogarithmBase());
@@ -89,7 +89,7 @@ public class DefaultNumericAxisTests {
 
         axis.setLogAxis(false);
         assertFalse(axis.isLogAxis());
-        axis.updateCachedVariables();
+        axis.updateCachedTransforms();
         tickValues.clear();
         axis.calculateMinorTickValues(tickValues);
     }

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/OscilloscopeAxisTests.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/OscilloscopeAxisTests.java
@@ -86,7 +86,7 @@ public class OscilloscopeAxisTests {
         final OscilloscopeAxis axis = new OscilloscopeAxis("axis title", 0.0, 100.0, 10.0);
 
         assertDoesNotThrow(() -> axis.setSide(Side.BOTTOM));
-        assertDoesNotThrow(axis::updateCachedVariables);
+        assertDoesNotThrow(axis::updateCachedTransforms);
 
         final double zero = axis.getDisplayPosition(axis.getValueForDisplay(0));
         assertEquals(0.0, zero);
@@ -167,13 +167,13 @@ public class OscilloscopeAxisTests {
         axis.setTickUnitSupplier(testTickUnitSupplier);
         assertEquals(testTickUnitSupplier, axis.getTickUnitSupplier());
 
-        assertDoesNotThrow(axis::updateCachedVariables);
+        assertDoesNotThrow(axis::updateCachedTransforms);
 
         assertDoesNotThrow(() -> axis.setSide(Side.BOTTOM));
-        assertDoesNotThrow(axis::updateCachedVariables);
+        assertDoesNotThrow(axis::updateCachedTransforms);
 
         assertDoesNotThrow(() -> axis.setSide(Side.LEFT));
-        assertDoesNotThrow(axis::updateCachedVariables);
+        assertDoesNotThrow(axis::updateCachedTransforms);
 
         assertNotNull(axis.getAxisTransform());
 

--- a/chartfx-dataset/pom.xml
+++ b/chartfx-dataset/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>dataset</artifactId>
     <name>chartfx-dataset</name>
     <properties>
-        <project.moduleName>io.fair-acc.dataset</project.moduleName>
+        <project.moduleName>io.fair_acc.dataset</project.moduleName>
     </properties>
 
     <description>

--- a/chartfx-generate/pom.xml
+++ b/chartfx-generate/pom.xml
@@ -14,7 +14,7 @@
     <name>chartfx-generate</name>
     <packaging>maven-plugin</packaging>
     <properties>
-        <project.moduleName>io.fair-acc.generate</project.moduleName>
+        <project.moduleName>io.fair_acc.generate</project.moduleName>
     </properties>
 
 

--- a/chartfx-math/pom.xml
+++ b/chartfx-math/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>math</artifactId>
     <name>chartfx_math</name>
     <properties>
-        <project.moduleName>io.fair-acc.math</project.moduleName>
+        <project.moduleName>io.fair_acc.math</project.moduleName>
     </properties>
 
     <description>

--- a/chartfx-report/pom.xml
+++ b/chartfx-report/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>report</artifactId>
     <name>chartfx-report</name>
 
+    <properties>
+        <project.moduleName>io.fair_acc.chartfx_report</project.moduleName>
+    </properties>
+
     <description>
         Container for handling testing and code coverage reports
     </description>

--- a/chartfx-samples/pom.xml
+++ b/chartfx-samples/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>samples</artifactId>
     <name>chartfx-samples</name>
     <properties>
-        <project.moduleName>io.fair-acc.samples</project.moduleName>
+        <project.moduleName>io.fair_acc.samples</project.moduleName>
     </properties>
 
     <description>

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ErrorDataSetRendererStylingSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ErrorDataSetRendererStylingSample.java
@@ -9,7 +9,6 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
-import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
@@ -41,13 +40,11 @@ import io.fair_acc.dataset.spi.DefaultErrorDataSet;
 import io.fair_acc.dataset.testdata.spi.*;
 import io.fair_acc.dataset.utils.ProcessingProfiler;
 
-public class ErrorDataSetRendererStylingSample extends Application {
+public class ErrorDataSetRendererStylingSample extends ChartSample {
     private static final String STOP_TIMER = "stop timer";
     private static final String START_TIMER = "start timer";
     private static final Logger LOGGER = LoggerFactory.getLogger(RollingBufferSample.class);
     private static final int DEBUG_UPDATE_RATE = 1000;
-    private static final int DEFAULT_WIDTH = 1200;
-    private static final int DEFAULT_HEIGHT = 600;
     private static final int UPDATE_DELAY = 1000; // [ms]
     private static final int UPDATE_PERIOD = 100; // [ms]
     private static final double N_MAX_SAMPLES = 10_000;
@@ -432,15 +429,12 @@ public class ErrorDataSetRendererStylingSample extends Application {
     }
 
     @Override
-    public void start(final Stage primaryStage) {
+    public Node getChartPanel(final Stage primaryStage) {
         ProcessingProfiler.setVerboseOutputState(false);
         ProcessingProfiler.setLoggerOutputState(true);
         ProcessingProfiler.setDebugState(false);
 
         final BorderPane root = new BorderPane();
-
-        final Scene scene = new Scene(root, ErrorDataSetRendererStylingSample.DEFAULT_WIDTH,
-                ErrorDataSetRendererStylingSample.DEFAULT_HEIGHT);
 
         final DefaultNumericAxis xAxis = new DefaultNumericAxis();
         xAxis.setUnit("Largeness");
@@ -457,7 +451,6 @@ public class ErrorDataSetRendererStylingSample extends Application {
         final ErrorDataSetRenderer errorRenderer = new ErrorDataSetRenderer();
         chart.getRenderers().set(0, errorRenderer);
         chart.getPlugins().add(new Zoomer());
-        chart.getPlugins().add(new Panner());
         chart.getPlugins().add(new EditAxis());
         chart.getPlugins().add(new DataPointTooltip());
         chart.getPlugins().add(new TableViewer());
@@ -529,11 +522,8 @@ public class ErrorDataSetRendererStylingSample extends Application {
         ProcessingProfiler.getTimeDiff(startTime, "adding chart into StackPane");
 
         startTime = ProcessingProfiler.getTimeStamp();
-        primaryStage.setTitle(this.getClass().getSimpleName());
-        primaryStage.setScene(scene);
-        primaryStage.setOnCloseRequest(evt -> Platform.exit());
-        primaryStage.show();
         ProcessingProfiler.getTimeDiff(startTime, "for showing");
+        return root;
     }
 
     /**

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/LogAxisSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/LogAxisSample.java
@@ -30,9 +30,7 @@ public class LogAxisSample extends ChartSample {
         // yAxis.setLogarithmBase(2);
 
         final XYChart chart = new XYChart(xAxis, yAxis);
-        final Zoomer zoomer = new Zoomer();
-        zoomer.setPannerEnabled(false); // not recommended (ie. Axes do not support complex numbers, e.g. 'log(-1)')
-        chart.getPlugins().add(zoomer); // zoom around
+        chart.getPlugins().add(new Zoomer()); // zoom around
         chart.getPlugins().add(new EditAxis()); // manually modify axis
 
         root.getChildren().add(chart);

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <sha1 />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.moduleName>io.fair-acc.chartfx-parent</project.moduleName>
+        <project.moduleName>io.fair_acc.chartfx_parent</project.moduleName>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 


### PR DESCRIPTION
Previously the zoomer would perform the scroll-zoom and panning calculations in data coordinates. This is identical to pixel coordinates for linear axes, but for e.g. log axes this leads to strange behaviour since it can result in negative data values.

This changes the Pan and pan and scroll behaviour, the rectangle zoom was naturally always using screen coordinates anyway, so this should also be more consistent.

To archive this a change to AbstractAxis was necessary to update cached variables on range change.

If the axis gets changed multiple times during event handling, but the cache is only updated during layout, axes transforms from the event handlers use outdated transformations. This has the effect that e.g. panning only applies the first mouse event in each pulse and the panning is a lot slower than the actual mouse movement.

Also incorporates a small fix in the pom to use valid automatic module names, converts the ErrorDataSetRendererStylingSample to a correct FxSampler sample and fixes 2 small bugs:
- the cached value of isLogAxis in NumericAxis was never updated so it could not be switched by its property
- the Plugins have been changed to use Panes instead of Groups for Positioning, resolving a bug where relayouting during an ongoing zoom action would shift the zoom rect to the upper left corner.