### PR TITLE
minor fixes

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
@@ -947,7 +947,7 @@ public abstract class Chart extends Region implements EventSource, Measurable {
         benchLockDataSets = recorder.newDebugDuration("chart-lockDataSets");
         benchUpdateAxisRange = recorder.newDuration("chart-updateAxisRange");
         benchDrawAxes = recorder.newDuration("chart-drawAxes");
-        benchDrawCanvas = recorder.newDuration("chart-drawCanvas");
+        benchDrawCanvas = recorder.newDebugDuration("chart-drawCanvas");
     }
 
     private DurationMeasure benchPreLayout = DurationMeasure.DISABLED;

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -298,8 +298,9 @@ public class XYChart extends Chart {
             } else if (axis == getYAxis()) {
                 axis.setRecorder(recorder.addPrefix("y"));
             } else {
-                axis.setRecorder(recorder.addPrefix("axis" + i++));
+                axis.setRecorder(recorder.addPrefix("axis" + i));
             }
+            i++;
         }
         i = 0;
         gridRenderer.setRecorder(recorder);
@@ -323,8 +324,8 @@ public class XYChart extends Chart {
     @Override
     public void setRecorder(MeasurementRecorder recorder) {
         super.setRecorder(recorder);
-        benchDrawGrid = recorder.newDebugDuration("xychart-drawGrid");
-        benchDrawData = recorder.newDebugDuration("xychart-drawData");
+        benchDrawGrid = recorder.newDuration("xychart-drawGrid");
+        benchDrawData = recorder.newDuration("xychart-drawData");
     }
 
     private DurationMeasure benchDrawGrid = DurationMeasure.DISABLED;

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/BenchPlugin.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/BenchPlugin.java
@@ -1,11 +1,8 @@
 package io.fair_acc.chartfx.plugins;
 
-import io.fair_acc.bench.BenchLevel;
-import io.fair_acc.bench.MeasurementRecorder;
-import io.fair_acc.chartfx.XYChart;
-import io.fair_acc.chartfx.bench.LiveDisplayRecorder;
-import io.fair_acc.chartfx.utils.FXUtils;
-import io.fair_acc.dataset.utils.AssertUtils;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.event.ActionEvent;
@@ -15,10 +12,15 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
+
 import org.kordamp.ikonli.javafx.FontIcon;
 
-import java.util.Optional;
-import java.util.function.UnaryOperator;
+import io.fair_acc.bench.BenchLevel;
+import io.fair_acc.bench.MeasurementRecorder;
+import io.fair_acc.chartfx.XYChart;
+import io.fair_acc.chartfx.bench.LiveDisplayRecorder;
+import io.fair_acc.chartfx.utils.FXUtils;
+import io.fair_acc.dataset.utils.AssertUtils;
 
 /**
  * Experimental plugin that measures and displays the internal
@@ -83,8 +85,8 @@ public class BenchPlugin extends ChartPlugin {
         if (!enabled.get() && getChart() != null && getChart() instanceof XYChart) {
             XYChart chart = (XYChart) getChart();
             String title = Optional.ofNullable(chart.getTitle())
-                    .filter(string -> !string.isEmpty())
-                    .orElse("Benchmark");
+                                   .filter(string -> !string.isEmpty())
+                                   .orElse("Benchmark");
             LiveDisplayRecorder recorder = LiveDisplayRecorder.createChart(title, pane -> {
                 Scene scene = new Scene(pane);
                 scene.getStylesheets().addAll(chart.getScene().getStylesheets());
@@ -106,8 +108,6 @@ public class BenchPlugin extends ChartPlugin {
         }
     }
 
-    private static final Runnable NO_OP = () -> {
-    };
+    private static final Runnable NO_OP = () -> {};
     private Runnable resetRecorder = NO_OP;
-
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/BenchPlugin.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/BenchPlugin.java
@@ -39,6 +39,7 @@ public class BenchPlugin extends ChartPlugin {
         final Button enableBtn = new Button(null, new FontIcon(ICON_ENABLE_BENCH));
         enableBtn.setPadding(new Insets(3, 3, 3, 3));
         enableBtn.setTooltip(new Tooltip("starts displaying live benchmark stats"));
+        enableBtn.disableProperty().bind(chartProperty().isNull());
         final Button disableBtn = new Button(null, new FontIcon(ICON_DISABLE_BENCH));
         disableBtn.setPadding(new Insets(3, 3, 3, 3));
         disableBtn.setTooltip(new Tooltip("stops displaying live benchmark stats"));

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -60,9 +60,9 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
         for (int i = getDatasetNodes().size() - 1; i >= 0; i--) {
             var dataSetNode = getDatasetNodes().get(i);
             if (dataSetNode.isVisible()) {
-                benchDrawSingle.start();
+                benchDrawOne.start();
                 render(getChart().getCanvas().getGraphicsContext2D(), dataSetNode.getDataSet(), dataSetNode);
-                benchDrawSingle.stop();
+                benchDrawOne.stop();
             }
         }
 
@@ -131,10 +131,11 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
 
     @Override
     public void setRecorder(MeasurementRecorder recorder) {
-        benchDrawAll = recorder.newDuration("xy-draw-all");
-        benchDrawSingle = recorder.newDebugDuration("xy-draw-single");
+        benchDrawAll = recorder.newDuration("xy-drawAll");
+        benchDrawOne = recorder.newTraceDuration("xy-drawOne");
     }
 
     private DurationMeasure benchDrawAll = DurationMeasure.DISABLED;
-    private DurationMeasure benchDrawSingle = DurationMeasure.DISABLED;
+    private DurationMeasure benchDrawOne = DurationMeasure.DISABLED;
+
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -1,5 +1,10 @@
 package io.fair_acc.chartfx.renderer.spi;
 
+import java.security.InvalidParameterException;
+
+import javafx.geometry.Orientation;
+import javafx.scene.canvas.GraphicsContext;
+
 import io.fair_acc.bench.DurationMeasure;
 import io.fair_acc.bench.Measurable;
 import io.fair_acc.bench.MeasurementRecorder;
@@ -10,10 +15,6 @@ import io.fair_acc.chartfx.axes.spi.AxisRange;
 import io.fair_acc.chartfx.ui.css.DataSetNode;
 import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.utils.AssertUtils;
-import javafx.geometry.Orientation;
-import javafx.scene.canvas.GraphicsContext;
-
-import java.security.InvalidParameterException;
 
 /**
  * Renderer that requires an X and a Y axis
@@ -36,7 +37,7 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
             return (XYChart) chart;
         }
         throw new InvalidParameterException("must be derivative of XYChart for renderer - "
-                + this.getClass().getSimpleName());
+                                            + this.getClass().getSimpleName());
     }
 
     @Override

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -1,10 +1,5 @@
 package io.fair_acc.chartfx.renderer.spi;
 
-import java.security.InvalidParameterException;
-
-import javafx.geometry.Orientation;
-import javafx.scene.canvas.GraphicsContext;
-
 import io.fair_acc.bench.DurationMeasure;
 import io.fair_acc.bench.Measurable;
 import io.fair_acc.bench.MeasurementRecorder;
@@ -15,6 +10,10 @@ import io.fair_acc.chartfx.axes.spi.AxisRange;
 import io.fair_acc.chartfx.ui.css.DataSetNode;
 import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.utils.AssertUtils;
+import javafx.geometry.Orientation;
+import javafx.scene.canvas.GraphicsContext;
+
+import java.security.InvalidParameterException;
 
 /**
  * Renderer that requires an X and a Y axis
@@ -37,7 +36,7 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
             return (XYChart) chart;
         }
         throw new InvalidParameterException("must be derivative of XYChart for renderer - "
-                                            + this.getClass().getSimpleName());
+                + this.getClass().getSimpleName());
     }
 
     @Override
@@ -137,5 +136,4 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
 
     private DurationMeasure benchDrawAll = DurationMeasure.DISABLED;
     private DurationMeasure benchDrawOne = DurationMeasure.DISABLED;
-
 }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -132,7 +132,7 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
     @Override
     public void setRecorder(MeasurementRecorder recorder) {
         benchDrawAll = recorder.newDuration("xy-draw-all");
-        benchDrawSingle = recorder.newDuration("xy-draw-single");
+        benchDrawSingle = recorder.newDebugDuration("xy-draw-single");
     }
 
     private DurationMeasure benchDrawAll = DurationMeasure.DISABLED;

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/GridRenderer.java
@@ -392,7 +392,7 @@ public class GridRenderer extends Parent implements Renderer {
 
     @Override
     public void setRecorder(MeasurementRecorder recorder) {
-        benchDrawGrid = recorder.newDuration("grid-drawGrid");
+        benchDrawGrid = recorder.newDebugDuration("grid-drawGrid");
     }
 
     private DurationMeasure benchDrawGrid = DurationMeasure.DISABLED;

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/events/BitState.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/events/BitState.java
@@ -1,8 +1,8 @@
 package io.fair_acc.dataset.events;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.IntSupplier;
@@ -167,7 +167,7 @@ public abstract class BitState implements StateListener {
 
     public BitState addChangeListener(StateListener listener) {
         if (changeListeners == null) {
-            changeListeners = new ArrayList<>();
+            changeListeners = new CopyOnWriteArrayList<>();
         }
         changeListeners.add(listener);
         return this;
@@ -175,7 +175,7 @@ public abstract class BitState implements StateListener {
 
     public BitState addInvalidateListener(StateListener listener) {
         if (invalidateListeners == null) {
-            invalidateListeners = new ArrayList<>();
+            invalidateListeners = new CopyOnWriteArrayList<>();
         }
         invalidateListeners.add(listener);
         return this;

--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/events/EventSource.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/events/EventSource.java
@@ -27,7 +27,6 @@ public interface EventSource extends StateListener {
      * @throws NullPointerException if the listener is null
      */
     default void addListener(StateListener listener) {
-        // TODO: handle multithreaded changes to the listener?
         Objects.requireNonNull(listener, "UpdateListener must not be null");
         getBitState().addChangeListener(listener);
         getBitState().getBits(listener); // initialize to the current state
@@ -48,10 +47,8 @@ public interface EventSource extends StateListener {
      * @throws NullPointerException if the listener is null
      */
     default void removeListener(StateListener listener) {
-        synchronized (getBitState()) {
-            Objects.requireNonNull(listener, "UpdateListener must not be null");
-            getBitState().removeChangeListener(listener);
-        }
+        Objects.requireNonNull(listener, "UpdateListener must not be null");
+        getBitState().removeChangeListener(listener);
     }
 
     default void accept(BitState source, int bits) {


### PR DESCRIPTION
PR with some tiny fixes:

* Made list of BitState listeners thread-safe
* Changed `BenchPlugin` to only allow a single open Window (fixes reset when a 2nd window is closed)
* Limited default bench measures to the most interesting ones
* Changed `SimplePerformanceMeter` to use the `Node::isDirtyEmpty` method instead of the `Node::dirtyBits` field which was changed/removed at  one point.