### PR TITLE
Bump versions and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Java CI
 
 on: [push, pull_request]
 env:
-  JAVA_REFERENCE_VERSION: 11
+  JAVA_REFERENCE_VERSION: 17
 
 jobs:
   test:
@@ -11,13 +11,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [11, 17, 19]
+        java: [17, 20]
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     environment: coverage # open environment, no critical secrets
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 25
       - name: Set version environment for version string

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -19,12 +19,12 @@ jobs:
     environment: coverity # environment needs to be manually triggered only use on demand
     steps:
       - name: Checkout branch on that the Coverity scan was dispatched
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         if: ${{ github.event_name == 'workflow_run' }}
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 25
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: ${{ github.event_name != 'workflow_run' }}
         with:
           fetch-depth: 25
@@ -41,15 +41,15 @@ jobs:
           echo "setting env:"
           cat ${GITHUB_ENV}
       - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK11
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'adopt'
       - name: Download Coverity Build Tool
         run: |

--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
-            <version>4.0.16-alpha</version>
+            <version>4.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -14,6 +14,7 @@ import io.fair_acc.bench.DurationMeasure;
 import io.fair_acc.bench.MeasurementRecorder;
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.axes.spi.AxisRange;
+import io.fair_acc.chartfx.axes.spi.CategoryAxis;
 import io.fair_acc.chartfx.plugins.ChartPlugin;
 import io.fair_acc.chartfx.renderer.PolarTickStep;
 import io.fair_acc.chartfx.renderer.Renderer;
@@ -227,6 +228,20 @@ public class XYChart extends Chart {
             // Trigger a redraw
             if (changed && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
                 axis.invalidateRange();
+            }
+
+            // Feature for backwards compatibility: Category axes that do not have
+            // their categories set copy the categories of the first dataset of the
+            // first renderer that is using this axis.
+            if (axis instanceof CategoryAxis catAxis) {
+                for (Renderer renderer : getRenderers()) {
+                    if (renderer.isUsingAxis(axis)) {
+                        if (!renderer.getDatasets().isEmpty()) {
+                            catAxis.updateCategories(renderer.getDatasets().get(0));
+                        }
+                        break;
+                    }
+                }
             }
         }
     }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/EditDataSet.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/EditDataSet.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
+import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -53,6 +54,7 @@ import io.fair_acc.chartfx.utils.FXUtils;
 import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.EditConstraints;
 import io.fair_acc.dataset.EditableDataSet;
+import io.fair_acc.dataset.events.ChartBits;
 
 /**
  *
@@ -150,6 +152,14 @@ public class EditDataSet extends TableViewer {
             event.consume();
         }
     };
+
+    @Override
+    public void runPostLayout() {
+        super.runPostLayout();
+        if (getChart().getBitState().isDirty(ChartBits.AxisMask | ChartBits.DataSetMask)) {
+            updateMarker();
+        }
+    }
 
     /**
      * Creates an event handler that handles a mouse drag on the node.
@@ -967,11 +977,6 @@ public class EditDataSet extends TableViewer {
             setOnMouseReleased(dragOver);
             setOnMouseDragOver(dragOver);
             // this.setOnMouseExited(dragOver);
-
-            // TODO: what are these?
-            //            xAxis.addListener(evt -> FXUtils.runFX(() -> this.setCenterX(getX())));
-            //            yAxis.addListener(evt -> FXUtils.runFX(() -> this.setCenterY(getY())));
-            //            dataSet.addListener(e -> FXUtils.runFX(this::update));
         }
 
         public void applyDrag(final double deltaX, final double deltaY) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/UpdateAxisLabels.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/UpdateAxisLabels.java
@@ -27,8 +27,10 @@ import io.fair_acc.dataset.events.StateListener;
  * TODO: revisit this plugin. we should be able to turn this into a single chart listener and an update method (ennerf)
  * TODO: this is using Chart::getDataSets() which doesn't really exist anymore
  *
+ * @deprecated prototype which is not usable yet and has to be adopted to the new layout
  * @author akrimm
  */
+@Deprecated
 public class UpdateAxisLabels extends ChartPlugin {
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateAxisLabels.class);
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/measurements/utils/ValueIndicatorSelector.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/measurements/utils/ValueIndicatorSelector.java
@@ -126,8 +126,7 @@ public class ValueIndicatorSelector extends GridPane {
                 valueIndicators.add((AbstractSingleValueIndicator) newPlugin);
             }
 
-            if (reuseIndicators.isSelected() && valueIndicatorsUser.size() < 2 && !valueIndicatorsUser.contains(newPlugin)) {
-                valueIndicatorsUser.add((AbstractSingleValueIndicator) newPlugin);
+            if (reuseIndicators.isSelected() && valueIndicatorsUser.size() < (indicatorListView.getSelectionModel().getSelectionMode() == SelectionMode.SINGLE ? 1 : 2) && !valueIndicatorsUser.contains(newPlugin)) {
                 indicatorListView.getSelectionModel().select((AbstractSingleValueIndicator) newPlugin);
             }
         }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/Renderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/Renderer.java
@@ -96,6 +96,17 @@ public interface Renderer extends Measurable.EmptyDefault {
     }
 
     /**
+     * Checks whether a renderer is actively using a given axis. The
+     * result is only valid after updateAxes has been called.
+     * <p>
+     * @param axis axis to be checked
+     * @return true if the renderer is actively using the given axis
+     */
+    default boolean isUsingAxis(Axis axis) {
+        return getAxes().contains(axis);
+    }
+
+    /**
      * Updates the range for the specified axis.
      * Does nothing if the axis is not used.
      *

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -12,6 +12,7 @@ import io.fair_acc.chartfx.Chart;
 import io.fair_acc.chartfx.XYChart;
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.axes.spi.AxisRange;
+import io.fair_acc.chartfx.axes.spi.CategoryAxis;
 import io.fair_acc.chartfx.ui.css.DataSetNode;
 import io.fair_acc.dataset.DataSet;
 import io.fair_acc.dataset.utils.AssertUtils;
@@ -85,6 +86,22 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
         if (yAxis == null) {
             yAxis = chart.getYAxis();
         }
+
+        // Update category axes (TODO: remove this API?)
+        if (!getDatasets().isEmpty()) {
+            var ds = getDatasets().get(0);
+            if (xAxis instanceof CategoryAxis xCat) {
+                xCat.updateCategories(ds);
+            }
+            if (yAxis instanceof CategoryAxis yCat) {
+                yCat.updateCategories(ds);
+            }
+        }
+    }
+
+    @Override
+    public boolean isUsingAxis(Axis axis) {
+        return axis == xAxis || axis == yAxis;
     }
 
     protected Axis ensureAxisInChart(Axis axis) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXYZ.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXYZ.java
@@ -38,6 +38,11 @@ public abstract class AbstractRendererXYZ<R extends AbstractRendererXYZ<R>> exte
     }
 
     @Override
+    public boolean isUsingAxis(Axis axis) {
+        return super.isUsingAxis(axis) || axis == zAxis;
+    }
+
+    @Override
     public void updateAxisRange(Axis axis, AxisRange range) {
         super.updateAxisRange(axis, range);
         if (axis == zAxis) {

--- a/chartfx-generate/pom.xml
+++ b/chartfx-generate/pom.xml
@@ -27,18 +27,20 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.6.3</version>
+            <version>3.9.4</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
-        </dependency>
+            <scope>provided</scope>
+         </dependency>
     </dependencies>
 
     <build>
@@ -46,7 +48,7 @@
             <plugin> <!-- move descriptor goal from process-classes to compile phase so that `mvn clean compile` works -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.9.0</version>
                 <executions>
                     <execution>
                         <id>earlierPluginXML</id>
@@ -72,6 +74,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin> <!-- attaching the javadoc fails the build because maven-project introduces a dependency with an invalid module descriptor -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/chartfx-math/pom.xml
+++ b/chartfx-math/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>net.jafama</groupId>
             <artifactId>jafama</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chartfx-samples/pom.xml
+++ b/chartfx-samples/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>net.jafama</groupId>
             <artifactId>jafama</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency> <!-- Hierarchy debugging -->
             <groupId>net.raumzeitfalle.fx</groupId>

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/EditDataSetSample.java
@@ -38,7 +38,6 @@ public class EditDataSetSample extends ChartSample {
         chart.getPlugins().add(new EditAxis());
         chart.getPlugins().add(new EditDataSet());
         chart.getPlugins().add(new DataPointTooltip());
-        chart.getPlugins().add(new UpdateAxisLabels());
         root.getChildren().add(chart);
 
         final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1 (full change)");

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/TransposedDataSetSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/TransposedDataSetSample.java
@@ -156,7 +156,6 @@ public class TransposedDataSetSample extends ChartSample {
         final XYChart chart = new XYChart();
         chart.getPlugins().add(new Zoomer());
         chart.getPlugins().add(new EditAxis());
-        chart.getPlugins().add(new UpdateAxisLabels());
         chart.getXAxis().setAutoRanging(true);
         chart.getYAxis().setAutoRanging(true);
         VBox.setVgrow(chart, Priority.ALWAYS);

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/math/ShortTimeFourierTransformSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/math/ShortTimeFourierTransformSample.java
@@ -97,7 +97,6 @@ public class ShortTimeFourierTransformSample extends ChartSample {
         // rawData chart
         chart3 = new XYChart();
         chart3.getXAxis().setAutoUnitScaling(true);
-        chart3.getPlugins().add(new UpdateAxisLabels());
         chart3.getPlugins().add(new Zoomer());
         chart3.getPlugins().add(new EditAxis());
         chart3.getRenderers().add(new MetaDataRenderer(chart3));
@@ -122,7 +121,6 @@ public class ShortTimeFourierTransformSample extends ChartSample {
         contourChartRenderer1.getAxes().setAll(xAxis1, yAxis1, zAxis1);
         chart1.getAxes().addAll(contourChartRenderer1.getAxes());
         // Add plugins after all axes are correctly set up
-        chart1.getPlugins().add(new UpdateAxisLabels());
         chart1.getPlugins().add(new Zoomer());
         chart1.getPlugins().add(new EditAxis());
         chart1.getDatasets().add(TransposedDataSet.transpose(stftData, true));
@@ -145,7 +143,6 @@ public class ShortTimeFourierTransformSample extends ChartSample {
         contourChartRenderer2.getAxes().setAll(xAxis2, yAxis2, zAxis2);
         chart2.getAxes().addAll(contourChartRenderer2.getAxes());
         chart2.getRenderers().add(new MetaDataRenderer(chart2));
-        chart2.getPlugins().add(new UpdateAxisLabels());
         chart2.getPlugins().add(new Zoomer());
         chart2.getPlugins().add(new EditAxis());
         chart2.getDatasets().add(waveletData);

--- a/pom.xml
+++ b/pom.xml
@@ -35,22 +35,23 @@
         <sha1 />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.moduleName>io.fair_acc.chartfx_parent</project.moduleName>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
-        <chartfx.javafx.version>13.0.1</chartfx.javafx.version>
+        <!-- starting with javafx 17, the chart will not be garbage collected as soon as a plugin is present -->
+        <chartfx.javafx.version>16</chartfx.javafx.version>
         <chartfx.controlsfx.version>11.1.2</chartfx.controlsfx.version>
         <chartfx.ikonli.version>12.3.1</chartfx.ikonli.version>
         <chartfx.javafxsvg.version>1.3.0</chartfx.javafxsvg.version>
-        <version.commons-lang3>3.12.0</version.commons-lang3>
+        <version.commons-lang3>3.13.0</version.commons-lang3>
 
-        <chartfx.slf4j.version>2.0.6</chartfx.slf4j.version>
-        <chartfx.junit.jupiter.version>5.9.2</chartfx.junit.jupiter.version>
+        <chartfx.slf4j.version>2.0.9</chartfx.slf4j.version>
+        <chartfx.junit.jupiter.version>5.10.0</chartfx.junit.jupiter.version>
         <chartfx.awaitility.version>4.2.0</chartfx.awaitility.version>
         <chartfx.jacoco.version>0.8.8</chartfx.jacoco.version>
         <chartfx.surefire.version>3.0.0-M9</chartfx.surefire.version>
 
-        <version.jetbrains.annotations>21.0.1</version.jetbrains.annotations>
+        <version.jetbrains.annotations>24.0.1</version.jetbrains.annotations>
         <version.maven-gpg-plugin>3.0.1</version.maven-gpg-plugin>
     </properties>
 
@@ -115,12 +116,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <!-- put your configurations here -->
                     </configuration>
@@ -144,12 +145,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.0.1</version> <!-- use old version to ignore module system errors -->
                     <configuration>
                         <links>
                             <link>https://openjfx.io/javadoc/12/</link>
@@ -180,7 +181,7 @@
                 <plugin> <!-- Use current plugin version because of MNG-5346-->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>io.fair-acc</groupId>
@@ -355,7 +356,7 @@
         <dependency>
             <groupId>de.sandec</groupId>
             <artifactId>JMemoryBuddy</artifactId>
-            <version>0.2.6</version>
+            <version>0.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* bump the main java version from 11 to 17 and add a 21 build.
* bump javafx to 16
  * all later versions trigger the memory leak check in our unittests. I followed it up to it being triggered by charts having at least one plugin, while an anonymous ChartPlugin does not trigger it. It seems to be triggered by the listener on the chartProperty having references to the chart in its Closure.
* bump all other plugin references
  * except javadoc, which causes jigsaw/module-system related errors if updated to the most recent version.
* update github actions to current versions.
* address leftovers from the previous PRs
  * Measurements: remove unused indicators
  * UpdateAxisPlugin: disable for now since it was not completely implemented anyhow and has to be adapted to the event system
  * EditDataSet: recompute selector ui element positions on axis or data changes
  * CategoryAxis: reenable updating the labels from dataset labels