### PR TITLE
changed label setting to match 11.2.7 behavior

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/XYChart.java
@@ -14,7 +14,6 @@ import io.fair_acc.bench.DurationMeasure;
 import io.fair_acc.bench.MeasurementRecorder;
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.axes.spi.AxisRange;
-import io.fair_acc.chartfx.axes.spi.CategoryAxis;
 import io.fair_acc.chartfx.plugins.ChartPlugin;
 import io.fair_acc.chartfx.renderer.PolarTickStep;
 import io.fair_acc.chartfx.renderer.Renderer;
@@ -228,20 +227,6 @@ public class XYChart extends Chart {
             // Trigger a redraw
             if (changed && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
                 axis.invalidateRange();
-            }
-
-            // Feature for backwards compatibility: Category axes that do not have
-            // their categories set copy the categories of the first dataset of the
-            // first renderer that is using this axis.
-            if (axis instanceof CategoryAxis catAxis) {
-                for (Renderer renderer : getRenderers()) {
-                    if (renderer.isUsingAxis(axis)) {
-                        if (!renderer.getDatasets().isEmpty()) {
-                            catAxis.updateCategories(renderer.getDatasets().get(0));
-                        }
-                        break;
-                    }
-                }
             }
         }
     }

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/CategoryAxis.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/CategoryAxis.java
@@ -157,7 +157,7 @@ public final class CategoryAxis extends DefaultNumericAxis {
      * @return true is categories were modified, false otherwise
      */
     public boolean updateCategories(final DataSet dataSet) {
-        if (dataSet == null || forceAxisCategories) {
+        if (dataSet == null || !dataSet.hasDataLabels() || forceAxisCategories) {
             return false;
         }
 

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/Renderer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/Renderer.java
@@ -96,17 +96,6 @@ public interface Renderer extends Measurable.EmptyDefault {
     }
 
     /**
-     * Checks whether a renderer is actively using a given axis. The
-     * result is only valid after updateAxes has been called.
-     * <p>
-     * @param axis axis to be checked
-     * @return true if the renderer is actively using the given axis
-     */
-    default boolean isUsingAxis(Axis axis) {
-        return getAxes().contains(axis);
-    }
-
-    /**
      * Updates the range for the specified axis.
      * Does nothing if the axis is not used.
      *

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -87,21 +87,14 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
             yAxis = chart.getYAxis();
         }
 
-        // Update category axes (TODO: remove this API?)
-        if (!getDatasets().isEmpty()) {
-            var ds = getDatasets().get(0);
-            if (xAxis instanceof CategoryAxis xCat) {
-                xCat.updateCategories(ds);
-            }
-            if (yAxis instanceof CategoryAxis yCat) {
-                yCat.updateCategories(ds);
-            }
+        // For backwards compatibility: A CategoryAxis without explicitly set
+        // categories copies the labels of the first dataset that is using it.
+        if (xAxis instanceof CategoryAxis axis && !getDatasets().isEmpty()) {
+            axis.updateCategories(getDatasets().get(0));
         }
-    }
-
-    @Override
-    public boolean isUsingAxis(Axis axis) {
-        return axis == xAxis || axis == yAxis;
+        if (yAxis instanceof CategoryAxis axis && !getDatasets().isEmpty()) {
+            axis.updateCategories(getDatasets().get(0));
+        }
     }
 
     protected Axis ensureAxisInChart(Axis axis) {

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXYZ.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXYZ.java
@@ -38,11 +38,6 @@ public abstract class AbstractRendererXYZ<R extends AbstractRendererXYZ<R>> exte
     }
 
     @Override
-    public boolean isUsingAxis(Axis axis) {
-        return super.isUsingAxis(axis) || axis == zAxis;
-    }
-
-    @Override
     public void updateAxisRange(Axis axis, AxisRange range) {
         super.updateAxisRange(axis, range);
         if (axis == zAxis) {


### PR DESCRIPTION
I double checked the automatic axis-label setting, and the 11.2.7 behavior was that each renderer tries to use the first dataset. Once the labels get set, a boolean state ensures that the labels do not get overwritten later.

This PR changes the behavior to match the 11.2.7 release.