### PR TITLE
RotatedAxisLabelSample: Disable AutoRanging

### DIFF
--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RotatedAxisLabelSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/RotatedAxisLabelSample.java
@@ -98,6 +98,7 @@ public class RotatedAxisLabelSample extends ChartSample {
 
     private static DefaultNumericAxis getSynchedAxis(DefaultNumericAxis orig, String newAxisName) {
         final DefaultNumericAxis axis = new DefaultNumericAxis(newAxisName);
+        axis.setAutoRanging(false);
         axis.minProperty().bind(orig.minProperty());
         axis.maxProperty().bind(orig.maxProperty());
         axis.getTickLabelStyle().setRotate(orig.getTickLabelStyle().getRotate());


### PR DESCRIPTION
Having autoranging enabled on synchronized axes with bound min/max properties results in errors when the bound properties are modified by the autoraning algorithm.