### PR TITLE
Zoomer: add a user definable predicate for panning

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
@@ -95,7 +95,7 @@ public class Zoomer extends ChartPlugin {
     private final BooleanProperty autoZoomEnable = new SimpleBooleanProperty(this, "enableAutoZoom", false);
     private final IntegerProperty autoZoomThreshold = new SimpleIntegerProperty(this, "autoZoomThreshold",
             DEFAULT_AUTO_ZOOM_THRESHOLD);
-    
+
     /**
      * Default zoom-in mouse filter passing on left mouse button (only).
      */

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ZoomerSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ZoomerSample.java
@@ -81,7 +81,7 @@ public class ZoomerSample extends ChartSample {
         zoomer5.setPanMouseFilter(event -> MouseEventsHelper.isOnlyPrimaryButtonDown(event) && MouseEventsHelper.isOnlyCtrlModifierDown(event));
         registerZoomerChangeListener(zoomer5, chart5.getTitle());
         chart5.getPlugins().add(zoomer5);
-        
+
         root.getChildren().addAll(chart1, chart2, chart3, chart4, chart5, label);
 
         return root;

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ZoomerSample.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/chart/ZoomerSample.java
@@ -20,6 +20,7 @@ import io.fair_acc.chartfx.Chart;
 import io.fair_acc.chartfx.XYChart;
 import io.fair_acc.chartfx.axes.Axis;
 import io.fair_acc.chartfx.axes.AxisMode;
+import io.fair_acc.chartfx.plugins.MouseEventsHelper;
 import io.fair_acc.chartfx.plugins.Zoomer;
 import io.fair_acc.chartfx.plugins.Zoomer.ZoomState;
 import io.fair_acc.dataset.DataSet;
@@ -68,13 +69,20 @@ public class ZoomerSample extends ChartSample {
         registerZoomerChangeListener(zoomer3, chart3.getTitle());
         chart3.getPlugins().add(zoomer3);
 
-        // chart with x-only zoom
+        // chart with y-only zoom
         final Chart chart4 = getTestChart("y-only zoom", testDataSet);
         Zoomer zoomer4 = new Zoomer(AxisMode.Y);
         registerZoomerChangeListener(zoomer4, chart4.getTitle());
         chart4.getPlugins().add(zoomer4);
 
-        root.getChildren().addAll(chart1, chart2, chart3, chart4, label);
+        // chart with control + LMB pan
+        final Chart chart5 = getTestChart("control + primary (left) button to pan", testDataSet);
+        Zoomer zoomer5 = new Zoomer();
+        zoomer5.setPanMouseFilter(event -> MouseEventsHelper.isOnlyPrimaryButtonDown(event) && MouseEventsHelper.isOnlyCtrlModifierDown(event));
+        registerZoomerChangeListener(zoomer5, chart5.getTitle());
+        chart5.getPlugins().add(zoomer5);
+        
+        root.getChildren().addAll(chart1, chart2, chart3, chart4, chart5, label);
 
         return root;
     }


### PR DESCRIPTION
This commit adds a user-definable predicate for panning to the Zoomer plugin.

It allows to replace the default predicate (middle mouse button) to something else, like it was possible with the now removed Panner plugin.

Sample code:
`zoomer.setPanMouseFilter(event -> MouseEventsHelper.isOnlyPrimaryButtonDown(event) && MouseEventsHelper.isOnlyCtrlModifierDown(event));
`

This is demonstrated in a new chart in the ZoomerSample.