### PR TITLE
LimitedIndexedTreeDataSet: fix yErrors

### DIFF
--- a/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/LimitedIndexedTreeDataSet.java
+++ b/chartfx-dataset/src/main/java/io/fair_acc/dataset/spi/LimitedIndexedTreeDataSet.java
@@ -447,7 +447,7 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
                 final double x = xValues[i];
                 final double y = yValues[i];
                 final double dx = xErrors[i];
-                final double dy = yValues[i];
+                final double dy = yErrors[i];
                 getAxisDescription(DIM_X).add(x - dx);
                 getAxisDescription(DIM_X).add(x + dx);
                 getAxisDescription(DIM_Y).add(y - dy);


### PR DESCRIPTION
Fixes a small typo bug that would initialize tze yErrors with the yValues instead of the supplied yValues.

Thanks to @zanzica for finding and repoting this.

closes #652 