### PR TITLE
Initial zoom in Zoomer is incorrect

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
@@ -794,11 +794,11 @@ public class Zoomer extends ChartPlugin {
             double dataMin;
             double dataMax;
             if (axis.getSide().isVertical()) {
-                dataMin = axis.getValueForDisplay(Math.min(axis.getHeight(), minPlotCoordinate.getY()));
-                dataMax = axis.getValueForDisplay(Math.min(axis.getHeight(), maxPlotCoordinate.getY()));
+                dataMin = axis.getValueForDisplay(Math.max(0, Math.min(axis.getHeight(), minPlotCoordinate.getY())));
+                dataMax = axis.getValueForDisplay(Math.max(0, Math.min(axis.getHeight(), maxPlotCoordinate.getY())));
             } else {
-                dataMin = axis.getValueForDisplay(Math.min(axis.getWidth(), minPlotCoordinate.getX()));
-                dataMax = axis.getValueForDisplay(Math.min(axis.getWidth(), maxPlotCoordinate.getX()));
+                dataMin = axis.getValueForDisplay(Math.max(0, Math.min(axis.getWidth(), minPlotCoordinate.getX())));
+                dataMax = axis.getValueForDisplay(Math.max(0, Math.min(axis.getWidth(), maxPlotCoordinate.getX())));
             }
             switch (getAxisMode()) {
             case X:

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/plugins/Zoomer.java
@@ -794,11 +794,11 @@ public class Zoomer extends ChartPlugin {
             double dataMin;
             double dataMax;
             if (axis.getSide().isVertical()) {
-                dataMin = axis.getValueForDisplay(minPlotCoordinate.getY());
-                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getY());
+                dataMin = axis.getValueForDisplay(Math.min(axis.getHeight(), minPlotCoordinate.getY()));
+                dataMax = axis.getValueForDisplay(Math.min(axis.getHeight(), maxPlotCoordinate.getY()));
             } else {
-                dataMin = axis.getValueForDisplay(minPlotCoordinate.getX());
-                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getX());
+                dataMin = axis.getValueForDisplay(Math.min(axis.getWidth(), minPlotCoordinate.getX()));
+                dataMax = axis.getValueForDisplay(Math.min(axis.getWidth(), maxPlotCoordinate.getX()));
             }
             switch (getAxisMode()) {
             case X:


### PR DESCRIPTION
+ Clamp the plot coordinates to the axis range before querying the values for display
+ Solves issue #636