### PR TITLE
DefaultAxisTransform: fix autoscale rounding direction

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/transforms/DefaultAxisTransform.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/axes/spi/transforms/DefaultAxisTransform.java
@@ -24,11 +24,11 @@ public class DefaultAxisTransform extends AbstractAxisTransform {
 
     @Override
     public double getRoundedMaximumRange(final double max) {
-        return Math.floor(max);
+        return Math.ceil(max);
     }
 
     @Override
     public double getRoundedMinimumRange(final double min) {
-        return Math.ceil(min);
+        return Math.floor(min);
     }
 }


### PR DESCRIPTION
DefaultAxisTransform is using the wrong rounding operation which leads to cut off range or missing labelling