### PR TITLE
Fix update of line dashes

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleUtil.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/css/StyleUtil.java
@@ -202,7 +202,7 @@ public class StyleUtil {
                 result[i] = array[i] == null ? 0 : array[i].doubleValue();
             }
             return result;
-        });
+        }, source);
     }
 
     public static void copyLineDashes(final GraphicsContext gc, Shape style) {


### PR DESCRIPTION
Changing `Number[] lineDashArrayProperty` will not update the binding `double[] lineDashesProperty` which is used by the renderer (via `StyleUtils`), thus any change will never be shown on screen.

This is just a quick fix, in my opinion it would be better to remove `lineDashesProperty` and use some variant of `toLineDashArray` to convert the `Number[]` when rendering