### PR TITLE
Chart: fix binding disposal when removing plugins

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/Chart.java
@@ -833,7 +833,7 @@ public abstract class Chart extends Region implements EventSource, Measurable {
     protected void pluginRemoved(final ChartPlugin plugin) {
         plugin.setChart(null);
         final Group group = pluginGroups.remove(plugin);
-        Bindings.unbindContent(group, plugin.getChartChildren());
+        Bindings.unbindContent(group.getChildren(), plugin.getChartChildren());
         group.getChildren().clear();
         pluginsArea.getChildren().remove(group);
     }


### PR DESCRIPTION
fix parameters to `Bindings.unbindContent` to actually dispose the binding created for the plugin group