### PR TITLE
Fix endless update loop in the presence of empty DataSet

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -122,6 +122,7 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
     }
 
     protected void updateAxisRange(DataSet dataSet, AxisRange range, int dim) {
+        if (dataSet.getDataCount() == 0) return;
         var dsRange = dataSet.getAxisDescription(dim);
         if (!dsRange.isDefined()) {
             dataSet.recomputeLimits(dim);

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/renderer/spi/AbstractRendererXY.java
@@ -122,7 +122,8 @@ public abstract class AbstractRendererXY<R extends AbstractRendererXY<R>> extend
     }
 
     protected void updateAxisRange(DataSet dataSet, AxisRange range, int dim) {
-        if (dataSet.getDataCount() == 0) return;
+        if (dataSet.getDataCount() == 0)
+            return;
         var dsRange = dataSet.getAxisDescription(dim);
         if (!dsRange.isDefined()) {
             dataSet.recomputeLimits(dim);


### PR DESCRIPTION
**Describe the bug**
Empty DataSet causes some kind of endless update loop somewhere.

**To Reproduce**
Create chart, add two empty datasets. Wait a second (to let JFX thread do pending tasks). After a second add a point to one of the datasets.

My reproducer in Kotlin
```kotlin
    val chart = frame("ChartFx", 1366.0 * 0.7, 768.0) {
        val xAxis = DefaultNumericAxis("x")
        val yAxis = DefaultNumericAxis("y")
        XYChart(xAxis, yAxis)
    }

    val first = DoubleDataSet("First")
    val second = DoubleDataSet("Second")

    withContext(Dispatchers.JavaFx) {
        chart.datasets.addAll(first, second)
    }

    delay(1000)
    first.add(150.0, 25.0)
```

**Observed behavior**
High CPU and GPU usage, exceptions like
```
java.util.concurrent.RejectedExecutionException: Task com.sun.javafx.tk.quantum.PaintRenderJob@3195e9e1[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@75ae38c1[Wrapped task = com.sun.javafx.tk.quantum.PresentingPainter@1ed15372]] rejected from com.sun.javafx.tk.quantum.QuantumRenderer@643b1d11[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 4074]
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841)
```
when trying to exit application.
Also endless loop (and the fix) was confirmed by a `println` statement inside `updateAxisRange` function.
The problem goes away as soon as a point added to the second empty dataset.

**Fix**
Suggested simple fix solves the problem.