### PR TITLE
Make it compile in Ubuntu.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                 <version>${chartfx.surefire.version}</version>
                 <configuration>
                     <!-- Jacoco prepare-agent builds some command-line params without which jacoco will not instrument. Hence it is important to add those command-line params here (${argLine} holds those params) -->
-                    <argLine>${argLine} -Duser.language=en -Duser.country=US -Xms256m -Xmx2048m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
+                    <argLine>${argLine} -Duser.language=en -Duser.country=US -Xms256m -Xmx4096m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
                     <forkCount>1</forkCount>
                     <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <runOrder>random</runOrder>


### PR DESCRIPTION
When "mvn compile install", it throw "java.lang.OutOfMemoryError: Java heap space: failed reallocation of scalar replaced objects".

Changing -Xmx2048m to -Xmx4096m in below of the pom.xml fixes this error.

            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
                <version>${chartfx.surefire.version}</version>
                <configuration>
                    <!-- Jacoco prepare-agent builds some command-line params without which jacoco will not instrument. Hence it is important to add those command-line params here (${argLine} holds those params) -->
                    <argLine>${argLine} -Duser.language=en -Duser.country=US -Xms256m -Xmx4096m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
                    <forkCount>1</forkCount>
                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                    <runOrder>random</runOrder>
                </configuration>
            </plugin>
